### PR TITLE
fix: update Nifty future stream method name

### DIFF
--- a/src/main/java/com/trader/backend/controller/NseInstrumentController.java
+++ b/src/main/java/com/trader/backend/controller/NseInstrumentController.java
@@ -56,7 +56,7 @@ public class NseInstrumentController {
     }
 @PostMapping("/nifty-fut-stream")
 public ResponseEntity<String> startNiftyFutStream() {
-    liveFeedService.streamNiftyFutAndTriggerFiltering();
+    liveFeedService.streamNiftyFutAndTriggerCEPE();
     return ResponseEntity.ok("📡 NIFTY FUT stream started");
 }
 @PostMapping("/save-nifty-futures")


### PR DESCRIPTION
## Summary
- fix Nifty future stream endpoint to use the updated `streamNiftyFutAndTriggerCEPE` service method

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a092bfc280832fa314347d1d973818