### PR TITLE
feat: simulate live ticks and market status

### DIFF
--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -43,13 +44,10 @@ import java.util.Locale;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Comparator;
-import com.trader.backend.service.NseInstrumentService;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.ConcurrentHashMap;
-import com.trader.backend.entity.NseInstrument;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import com.trader.backend.events.FilteredPremiumsUpdatedEvent;
 
@@ -63,6 +61,9 @@ public class LiveFeedService {
     private final NseInstrumentService nseInstrumentService;
     private final ObjectMapper om = new ObjectMapper();
     private final MongoTemplate mongoTemplate;
+    private final QuantAnalysisService quantAnalysisService;
+    @Value("${app.mock:false}")
+    private boolean mockMode;
 // Tracks currently subscribed CE/PE instruments for debug/monitoring
 private final Set<String> subscribed = ConcurrentHashMap.newKeySet();
     private final Sinks.Many<JsonNode> sink = Sinks.many().multicast().onBackpressureBuffer();
@@ -77,6 +78,12 @@ private final AtomicBoolean optionsStreamStarted = new AtomicBoolean(false);
 
   @PostConstruct
 public void initAutoStart() {
+    if (mockMode) {
+        log.info("🧪 Mock mode enabled - skipping live feed startup");
+        // streamNiftyFutAndTriggerCEPE(); // Nifty Future live ticks
+        // setupNiftyOptionsLiveFeed();   // Option chain live ticks
+        return;
+    }
     log.info("🚀 Starting auto init sequence...");
 
     // make sure token is valid before any network calls
@@ -302,7 +309,7 @@ public void initAutoStart() {
                 })
                 .subscribe(
                         tick -> {
-                            log.info("💥 Nifty Option Tick: {}", tick.toPrettyString());
+                            // log.debug("💥 Nifty Option Tick: {}", tick.toPrettyString());
                             sink.tryEmitNext((JsonNode) tick);
                         },
                         error -> log.error("❌ Option WS failed: ", error)
@@ -396,8 +403,25 @@ public void initAutoStart() {
                         .path("ltpc")
                         .path("ltp");
                 if (!ltpNode.isMissingNode()) {
-                    log.info("📈 Option tick: {} LTP={}", instrumentKey, ltpNode.asDouble());
-                    log.info("📊 Full tick for {} -> {}", instrumentKey, feed.toPrettyString());
+                    double ltp = ltpNode.asDouble();
+                    log.info("📈 Option tick: {} LTP={}", instrumentKey, ltp);
+
+                    var result = quantAnalysisService.analyze(instrumentKey, feed);
+                    if (result.signal() != QuantAnalysisService.Signal.NONE) {
+                        log.info("🎯 {} for {} → momentum={} volSpike={} imbalance={} noise={}",
+                                result.signal(), instrumentKey,
+                                String.format("%.4f", result.momentum()),
+                                String.format("%.2f", result.volumeSpike()),
+                                String.format("%.4f", result.imbalance()),
+                                String.format("%.2f", result.noise()));
+
+                        if (result.signal() == QuantAnalysisService.Signal.ENTRY_LONG
+                                || result.signal() == QuantAnalysisService.Signal.ENTRY_SHORT) {
+                            log.info("⏱ entry noted for {} at {} — scheduling exit in 5s", instrumentKey, ltp);
+                            Mono.delay(Duration.ofSeconds(5))
+                                    .subscribe(v -> log.info("⏳ exit triggered for {}", instrumentKey));
+                        }
+                    }
                 } else {
                     log.debug("⏳ tick for {}", instrumentKey);
                 }
@@ -450,9 +474,6 @@ JsonNode ltpNode = tick.path("feeds")
                 } else {
                     log.warn("⚠️ LTP not found in tick");
                 }
-
-                // Just log for debugging
-                log.info("📡 [Nifty Future] Tick → {}", tick.toPrettyString());
 
                 // Still emit tick to sink if needed
                 sink.tryEmitNext(tick);

--- a/src/main/java/com/trader/backend/service/MarketStatusService.java
+++ b/src/main/java/com/trader/backend/service/MarketStatusService.java
@@ -1,0 +1,26 @@
+package com.trader.backend.service;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/**
+ * Derives a coarse market status (bullish, bearish, neutral) from
+ * futures quantitative analysis results. This helps summarize the
+ * broader market direction during mock runs.
+ */
+@Component
+@Profile("mock")
+public class MarketStatusService {
+
+    private static final double THRESHOLD = 0.0005; // 0.05%
+
+    public MarketStatus determine(QuantAnalysisService.QuantAnalysisResult futuresResult) {
+        double m = futuresResult.momentum();
+        if (m > THRESHOLD) return MarketStatus.BULLISH;
+        if (m < -THRESHOLD) return MarketStatus.BEARISH;
+        return MarketStatus.NEUTRAL;
+    }
+
+    public enum MarketStatus { BULLISH, BEARISH, NEUTRAL }
+}
+

--- a/src/main/java/com/trader/backend/service/MockTickRunner.java
+++ b/src/main/java/com/trader/backend/service/MockTickRunner.java
@@ -1,0 +1,60 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Iterator;
+import java.time.Duration;
+import reactor.core.publisher.Mono;
+
+@Component
+@Profile("mock")
+@RequiredArgsConstructor
+@Slf4j
+public class MockTickRunner implements CommandLineRunner {
+
+    private final QuantAnalysisService quantAnalysisService;
+    private final SyntheticTickGenerator syntheticTickGenerator;
+    private final MarketStatusService marketStatusService;
+
+    @Override
+    public void run(String... args) throws Exception {
+        for (int i = 0; i < 20; i++) {
+            JsonNode tick = syntheticTickGenerator.next();
+            JsonNode feeds = tick.path("feeds");
+            Iterator<String> it = feeds.fieldNames();
+            QuantAnalysisService.QuantAnalysisResult futuresResult = null;
+            while (it.hasNext()) {
+                String key = it.next();
+                JsonNode feed = feeds.get(key);
+                QuantAnalysisService.QuantAnalysisResult r =
+                        quantAnalysisService.analyze(key, feed);
+                log.info("\uD83E\uDD14 [{}] momentum={} volSpike={} imbalance={} noise={} signal={}",
+                        key,
+                        String.format("%.4f", r.momentum()),
+                        String.format("%.2f", r.volumeSpike()),
+                        String.format("%.2f", r.imbalance()),
+                        String.format("%.2f", r.noise()),
+                        r.signal());
+                if (r.signal() == QuantAnalysisService.Signal.ENTRY_LONG
+                        || r.signal() == QuantAnalysisService.Signal.ENTRY_SHORT) {
+                    log.info("⏱ mock entry detected for {} — scheduling exit in 1s", key);
+                    Mono.delay(Duration.ofSeconds(1))
+                            .subscribe(v -> log.info("⏳ mock exit for {}", key));
+                }
+                if ("NSE_FO|64103".equals(key)) {
+                    futuresResult = r;
+                }
+            }
+            if (futuresResult != null) {
+                MarketStatusService.MarketStatus status = marketStatusService.determine(futuresResult);
+                log.info("\uD83D\uDCCA Market status: {}", status);
+            }
+            Thread.sleep(200); // simulate tick interval
+        }
+    }
+}

--- a/src/main/java/com/trader/backend/service/QuantAnalysisService.java
+++ b/src/main/java/com/trader/backend/service/QuantAnalysisService.java
@@ -1,0 +1,126 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Simple quantitative analysis on incoming tick data. The goal is to
+ * compute a few microstructure features (momentum, volume spike and
+ * order book imbalance) and produce coarse entry/exit signals. This is
+ * intentionally lightweight and stateful per instrument key so it can
+ * evolve over time as more ticks arrive.
+ */
+@Service
+@Slf4j
+public class QuantAnalysisService {
+
+    private static final int WINDOW = 20;
+    private static final double MOMENTUM_THRESHOLD = 0.001; // 0.1%
+    private static final double VOLUME_SPIKE_FACTOR = 1.5;
+    private static final double IMBALANCE_THRESHOLD = 0.2;
+    private static final double NOISE_THRESHOLD = 0.6; // fraction of direction flips
+
+    private final Map<String, Deque<Double>> midHistory = new ConcurrentHashMap<>();
+    private final Map<String, Deque<Double>> volHistory = new ConcurrentHashMap<>();
+    private final Map<String, Deque<Integer>> dirHistory = new ConcurrentHashMap<>();
+
+    public QuantAnalysisResult analyze(String instrumentKey, JsonNode feed) {
+        JsonNode marketFF = feed.path("fullFeed").path("marketFF");
+
+        double mid = computeMidPrice(marketFF);
+        Deque<Double> mids = midHistory.computeIfAbsent(instrumentKey, k -> new ArrayDeque<>());
+        double prevMid = mids.isEmpty() ? mid : mids.getLast();
+        double momentum = computeMomentum(prevMid, mid);
+        double noise = computeNoise(instrumentKey, prevMid, mid);
+        mids.addLast(mid);
+        if (mids.size() > WINDOW) mids.removeFirst();
+        double ltq = marketFF.path("ltpc").path("ltq").asDouble(0);
+        double volSpike = computeVolumeSpike(instrumentKey, ltq);
+        double imbalance = computeOrderBookImbalance(marketFF.path("marketLevel").path("bidAskQuote"));
+
+        Signal signal = determineSignal(momentum, volSpike, imbalance, noise);
+        return new QuantAnalysisResult(momentum, volSpike, imbalance, noise, signal);
+    }
+
+    private double computeMidPrice(JsonNode marketFF) {
+        JsonNode quotes = marketFF.path("marketLevel").path("bidAskQuote");
+        if (!quotes.isArray() || quotes.size() == 0) {
+            return marketFF.path("ltpc").path("ltp").asDouble(0);
+        }
+        JsonNode top = quotes.get(0);
+        double bid = top.path("bidP").asDouble(0);
+        double ask = top.path("askP").asDouble(0);
+        return (bid + ask) / 2.0;
+    }
+
+    private double computeOrderBookImbalance(JsonNode quotes) {
+        if (!quotes.isArray() || quotes.size() == 0) return 0;
+        double bidSum = 0;
+        double askSum = 0;
+        for (JsonNode level : quotes) {
+            bidSum += level.path("bidQ").asDouble(0);
+            askSum += level.path("askQ").asDouble(0);
+        }
+        double denom = bidSum + askSum;
+        if (denom == 0) return 0;
+        return (bidSum - askSum) / denom;
+    }
+
+    private double computeMomentum(double prev, double mid) {
+        if (prev == 0) return 0;
+        return (mid - prev) / prev;
+    }
+
+    private double computeVolumeSpike(String key, double ltq) {
+        Deque<Double> deque = volHistory.computeIfAbsent(key, k -> new ArrayDeque<>());
+        double avg = deque.stream().mapToDouble(Double::doubleValue).average().orElse(0);
+        deque.addLast(ltq);
+        if (deque.size() > WINDOW) deque.removeFirst();
+        if (avg == 0) return 0;
+        return ltq / avg;
+    }
+
+    private Signal determineSignal(double momentum, double volSpike, double imbalance, double noise) {
+        if (noise > NOISE_THRESHOLD) {
+            return Signal.EXIT;
+        }
+        if (momentum > MOMENTUM_THRESHOLD && volSpike > VOLUME_SPIKE_FACTOR && imbalance > IMBALANCE_THRESHOLD) {
+            return Signal.ENTRY_LONG;
+        }
+        if (momentum < -MOMENTUM_THRESHOLD && volSpike > VOLUME_SPIKE_FACTOR && imbalance < -IMBALANCE_THRESHOLD) {
+            return Signal.ENTRY_SHORT;
+        }
+        if (Math.abs(momentum) < MOMENTUM_THRESHOLD || Math.abs(imbalance) < IMBALANCE_THRESHOLD) {
+            return Signal.EXIT;
+        }
+        return Signal.NONE;
+    }
+
+    private double computeNoise(String key, double prev, double mid) {
+        Deque<Integer> deque = dirHistory.computeIfAbsent(key, k -> new ArrayDeque<>());
+        int dir = 0;
+        if (mid > prev) dir = 1; else if (mid < prev) dir = -1; else dir = 0;
+        if (dir != 0) {
+            deque.addLast(dir);
+            if (deque.size() > WINDOW) deque.removeFirst();
+        }
+        if (deque.size() < 2) return 0;
+        int flips = 0;
+        Integer[] arr = deque.toArray(new Integer[0]);
+        for (int i = 1; i < arr.length; i++) {
+            if (!arr[i].equals(arr[i-1])) flips++;
+        }
+        return (double) flips / (arr.length - 1);
+    }
+
+    public record QuantAnalysisResult(double momentum, double volumeSpike, double imbalance, double noise, Signal signal) { }
+
+    public enum Signal { ENTRY_LONG, ENTRY_SHORT, EXIT, NONE }
+}
+

--- a/src/main/java/com/trader/backend/service/SyntheticTickGenerator.java
+++ b/src/main/java/com/trader/backend/service/SyntheticTickGenerator.java
@@ -1,0 +1,80 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+/**
+ * Generates synthetic tick data that mimics the structure of
+ * the broker API feed. This allows offline testing without
+ * relying on recorded mock samples.
+ */
+@Component
+@Profile("mock")
+@Slf4j
+public class SyntheticTickGenerator {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Random random = new Random();
+
+    private double futurePrice = 24671.0;
+    private double optionPrice = 310.0;
+    private long timestamp = System.currentTimeMillis();
+
+    public JsonNode next() {
+        timestamp += 250;
+        futurePrice = randomWalk(futurePrice, 0.05);
+        optionPrice = randomWalk(optionPrice, 0.2);
+
+        ObjectNode root = mapper.createObjectNode();
+        ObjectNode feeds = root.putObject("feeds");
+        feeds.set("NSE_FO|64103", buildInstrumentNode(futurePrice, 24712.2));
+        feeds.set("NSE_FO|47161", buildInstrumentNode(optionPrice, 336.2));
+        return root;
+    }
+
+    private ObjectNode buildInstrumentNode(double price, double closePrice) {
+        ObjectNode instrument = mapper.createObjectNode();
+        ObjectNode fullFeed = instrument.putObject("fullFeed");
+        ObjectNode marketFF = fullFeed.putObject("marketFF");
+        ObjectNode ltpc = marketFF.putObject("ltpc");
+        ltpc.put("ltp", price);
+        ltpc.put("ltt", String.valueOf(timestamp));
+        ltpc.put("ltq", String.valueOf(randomVolume()));
+        ltpc.put("cp", closePrice);
+
+        ObjectNode marketLevel = marketFF.putObject("marketLevel");
+        ArrayNode quotes = marketLevel.putArray("bidAskQuote");
+        double spread = price * 0.0004;
+        double bid = price - spread / 2;
+        double ask = price + spread / 2;
+        quotes.add(buildQuote(bid, ask));
+        quotes.add(buildQuote(bid - spread, ask + spread));
+        return instrument;
+    }
+
+    private ObjectNode buildQuote(double bid, double ask) {
+        ObjectNode q = mapper.createObjectNode();
+        q.put("bidQ", String.valueOf(randomVolume()));
+        q.put("bidP", bid);
+        q.put("askQ", String.valueOf(randomVolume()));
+        q.put("askP", ask);
+        return q;
+    }
+
+    private int randomVolume() {
+        return 50 + random.nextInt(950);
+    }
+
+    private double randomWalk(double price, double volatilityPct) {
+        double change = price * volatilityPct / 100.0 * random.nextGaussian();
+        return price + change;
+    }
+}
+

--- a/src/test/java/com/trader/backend/service/QuantAnalysisServiceTest.java
+++ b/src/test/java/com/trader/backend/service/QuantAnalysisServiceTest.java
@@ -1,0 +1,49 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class QuantAnalysisServiceTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void detectsEntrySignal() throws Exception {
+        String tick1 = "{" +
+                "\"fullFeed\": { \"marketFF\": {" +
+                "\"ltpc\": {\"ltp\":310.0,\"ltq\":\"75\"}," +
+                "\"marketLevel\": { \"bidAskQuote\": [" +
+                "{\"bidQ\":\"375\",\"bidP\":306.9,\"askQ\":\"150\",\"askP\":310.0}," +
+                "{\"bidQ\":\"75\",\"bidP\":306.5,\"askQ\":\"225\",\"askP\":311.6}," +
+                "{\"bidQ\":\"300\",\"bidP\":305.2,\"askQ\":\"375\",\"askP\":315.6}," +
+                "{\"bidQ\":\"75\",\"bidP\":305.0,\"askQ\":\"150\",\"askP\":315.85}," +
+                "{\"bidQ\":\"75\",\"bidP\":304.0,\"askQ\":\"150\",\"askP\":315.9}" +
+                "] } } }" +
+                "}";
+
+        String tick2 = "{" +
+                "\"fullFeed\": { \"marketFF\": {" +
+                "\"ltpc\": {\"ltp\":320.0,\"ltq\":\"1000\"}," +
+                "\"marketLevel\": { \"bidAskQuote\": [" +
+                "{\"bidQ\":\"1000\",\"bidP\":320.0,\"askQ\":\"100\",\"askP\":321.0}" +
+                "] } } }" +
+                "}";
+
+        QuantAnalysisService svc = new QuantAnalysisService();
+        JsonNode j1 = mapper.readTree(tick1);
+        JsonNode j2 = mapper.readTree(tick2);
+
+        QuantAnalysisService.QuantAnalysisResult r1 = svc.analyze("NSE_FO|47161", j1);
+        assertEquals(QuantAnalysisService.Signal.EXIT, r1.signal());
+
+        QuantAnalysisService.QuantAnalysisResult r2 = svc.analyze("NSE_FO|47161", j2);
+        assertEquals(QuantAnalysisService.Signal.ENTRY_LONG, r2.signal());
+        assertTrue(r2.momentum() > 0);
+        assertTrue(r2.volumeSpike() > 1.5);
+        assertTrue(r2.imbalance() > 0.2);
+    }
+}
+

--- a/src/test/java/com/trader/backend/service/SyntheticTickGeneratorTest.java
+++ b/src/test/java/com/trader/backend/service/SyntheticTickGeneratorTest.java
@@ -1,0 +1,25 @@
+package com.trader.backend.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Basic structural test to ensure the synthetic generator produces
+ * ticks resembling the live broker feed.
+ */
+public class SyntheticTickGeneratorTest {
+
+    @Test
+    void generatesTickWithFeeds() {
+        SyntheticTickGenerator gen = new SyntheticTickGenerator();
+        JsonNode tick = gen.next();
+        JsonNode feeds = tick.get("feeds");
+        assertNotNull(feeds);
+        assertNotNull(feeds.get("NSE_FO|64103"));
+        JsonNode fut = feeds.get("NSE_FO|64103");
+        assertTrue(fut.path("fullFeed").path("marketFF").path("ltpc").has("ltp"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace static mock dataset with synthetic tick generator that mimics broker feed
- track overall market direction with a market-status helper and log it each iteration
- cover generator structure with a lightweight unit test
- silence raw tick logs and add timed exit messages around entry signals

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a098aa8718832f86b9591a2cb4ebdd