### PR TITLE
Make log levels configurable via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # backendforautobot
 
 - Auto-refreshes weekly NIFTY options after expiry and includes NIFTY future in live feed.
+
+## Log configuration
+
+Logging levels for the backend services are controlled through environment
+variables. The `application.properties` file uses placeholders such as
+
+```
+logging.level.com.trader.backend.service.LiveFeedService=${LIVEFEED_LOG_LEVEL:INFO}
+```
+
+Set the appropriate environment variable to adjust the verbosity for a
+specific component. The provided `railway.json` defines defaults for
+production (set to `INFO`) and debug (set to `DEBUG`) deployments, but these
+can be overridden to suit your needs.

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "environments": {
+    "production": {
+      "LIVEFEED_LOG_LEVEL": "INFO",
+      "UPSTOX_AUTH_LOG_LEVEL": "INFO",
+      "NSE_JSON_DOWNLOADER_LOG_LEVEL": "INFO",
+      "STREAM_CONTROLLER_LOG_LEVEL": "INFO",
+      "NSE_INSTRUMENT_LOG_LEVEL": "INFO",
+      "REACTOR_NETTY_HTTP_CLIENT_LOG_LEVEL": "INFO"
+    },
+    "debug": {
+      "LIVEFEED_LOG_LEVEL": "DEBUG",
+      "UPSTOX_AUTH_LOG_LEVEL": "DEBUG",
+      "NSE_JSON_DOWNLOADER_LOG_LEVEL": "DEBUG",
+      "STREAM_CONTROLLER_LOG_LEVEL": "DEBUG",
+      "NSE_INSTRUMENT_LOG_LEVEL": "DEBUG",
+      "REACTOR_NETTY_HTTP_CLIENT_LOG_LEVEL": "DEBUG"
+    }
+  }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,15 +7,15 @@ spring.data.mongodb.database=ClusterDev
 upstox.apiKey=97fde129-556b-4a84-9083-9fea5eb53fb0
 upstox.apiSecret=ofye1h1t8e
 upstox.webhookUri= https://backendforautobot-production.up.railway.app/auth
-logging.level.reactor.netty.http.client=DEBUG
+logging.level.reactor.netty.http.client=${REACTOR_NETTY_HTTP_CLIENT_LOG_LEVEL:INFO}
 
 spring.redis.host=localhost   # Redis later; leave like this
 spring.redis.port=6379
 upstox.accessToken=eyJ0eXAiOiJKV1QiLCJrZXlfaWQiOiJza192MS4wIiwiYWxnIjoiSFMyNTYifQ.eyJzdWIiOiIyU0M3WjkiLCJqdGkiOiI2ODIwNDk1Yzg2M2M4ODY1MDAxOGE4MmQiLCJpc011bHRpQ2xpZW50IjpmYWxzZSwiaXNQbHVzUGxhbiI6ZmFsc2UsImlhdCI6MTc0Njk0NjM5NiwiaXNzIjoidWRhcGktZ2F0ZXdheS1zZXJ2aWNlIiwiZXhwIjoxNzQ3MDAwODAwfQ.mLgDAxc1M6o_w_gCzbYtQXGjXOcEmCce2qDqixa4BDc
 # turn on DEBUG for your auth & feed services
-logging.level.com.trader.backend.service.UpstoxAuthService=DEBUG
-logging.level.com.trader.backend.service.LiveFeedService=DEBUG
-logging.level.com.trader.backend.scheduler.NseJsonDownloader=DEBUG
+logging.level.com.trader.backend.service.UpstoxAuthService=${UPSTOX_AUTH_LOG_LEVEL:INFO}
+logging.level.com.trader.backend.service.LiveFeedService=${LIVEFEED_LOG_LEVEL:INFO}
+logging.level.com.trader.backend.scheduler.NseJsonDownloader=${NSE_JSON_DOWNLOADER_LOG_LEVEL:INFO}
 # your Cloud-2 URL (include the ?1? if that?s what your UI shows)
 influx.url=https://us-east-1-1.aws.cloud2.influxdata.com
 
@@ -27,6 +27,6 @@ influx.org=Johntradecorp
 
 # the name of the bucket you created (e.g. ?Ticks?)
 influx.bucket=Ticks
-logging.level.com.trader.backend.service.StreamController=DEBUG
-logging.level.com.trader.backend.service.NseInstrumentService=DEBUG
+logging.level.com.trader.backend.service.StreamController=${STREAM_CONTROLLER_LOG_LEVEL:INFO}
+logging.level.com.trader.backend.service.NseInstrumentService=${NSE_INSTRUMENT_LOG_LEVEL:INFO}
 spring.main.allow-bean-definition-overriding=true


### PR DESCRIPTION
## Summary
- allow per-service log level overrides using environment variable placeholders in `application.properties`
- add `railway.json` to provide default log verbosity for production and debug deployments
- document logging configuration and environment variable usage

## Testing
- `./mvnw -q test` *(fails: Network is unreachable while resolving parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e7437ff8832fb2505f5ca5384f4f