### PR TITLE
Configure logback file rotation and optional log forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+logs/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # backendforautobot
 
 - Auto-refreshes weekly NIFTY options after expiry and includes NIFTY future in live feed.
+
+## Logging
+
+The application uses [Logback](https://logback.qos.ch/) for logging. Logs are written to
+`logs/app.log` with daily rotation and a maximum size of 10 MB per file.
+
+To forward logs to an external service such as Papertrail, Logtail or Graylog,
+configure the following environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `LOG_AGGREGATOR_HOST` | Hostname of the log collector. |
+| `LOG_AGGREGATOR_PORT` | TCP port of the collector. |
+| `LOG_AGGREGATOR_TOKEN` | Optional API key/token if required by your provider. |
+
+You can also set `LOG_DIR` to change the directory where local log files are
+stored (defaults to `logs`).

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context" name="LOG_DIR" source="LOG_DIR" defaultValue="logs"/>
+    <property name="FILE_NAME" value="app.log"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/${FILE_NAME}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/${FILE_NAME}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <springProperty scope="context" name="LOG_AGGREGATOR_HOST" source="LOG_AGGREGATOR_HOST"/>
+    <springProperty scope="context" name="LOG_AGGREGATOR_PORT" source="LOG_AGGREGATOR_PORT"/>
+
+    <if condition='property("LOG_AGGREGATOR_HOST").length() > 0 && property("LOG_AGGREGATOR_PORT").length() > 0'>
+        <then>
+            <appender name="SOCKET" class="ch.qos.logback.classic.net.SocketAppender">
+                <remoteHost>${LOG_AGGREGATOR_HOST}</remoteHost>
+                <port>${LOG_AGGREGATOR_PORT}</port>
+                <reconnectionDelay>10000</reconnectionDelay>
+            </appender>
+        </then>
+    </if>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <if condition='property("LOG_AGGREGATOR_HOST").length() > 0 && property("LOG_AGGREGATOR_PORT").length() > 0'>
+            <then>
+                <appender-ref ref="SOCKET"/>
+            </then>
+        </if>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add logback-spring.xml with rolling file appender to `logs/`
- support optional socket appender for forwarding logs to external collectors
- document logging environment variables in README and ignore generated log files

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e740810c832fb0123d6212db9fd2