### PR TITLE
chore: update URLs for AWS deployment

### DIFF
--- a/frontend/src/environments/environment.prod.ts
+++ b/frontend/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://backendforautobot-production.up.railway.app'
+  // API base URL now points to the AWS Elastic Beanstalk deployment
+  apiBaseUrl: 'https://autotradxxebbu-env.eba-vp9dhc3a.eu-north-1.elasticbeanstalk.com'
 };

--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -19,8 +19,10 @@ public class CorsConfig {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
 
-        // ✅ Set your frontend domain here
-        config.setAllowedOrigins(List.of("https://frontendfortheautobot.vercel.app","https://localhost:4200"));
+        // ✅ Allow the AWS-hosted frontend and local development
+        config.setAllowedOrigins(List.of(
+                "https://autotradxxebbu-env.eba-vp9dhc3a.eu-north-1.elasticbeanstalk.com",
+                "https://localhost:4200"));
 
         config.setAllowedHeaders(List.of("*"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/src/main/java/com/trader/backend/controller/AuthController.java
+++ b/src/main/java/com/trader/backend/controller/AuthController.java
@@ -46,7 +46,8 @@ public void handleUpstoxRedirect(@RequestParam Map<String, String> qs,
             .subscribe(); // fire and forget
 
         try {
-            response.sendRedirect("https://frontendfortheautobot.vercel.app/dashboard");
+            // Redirect to the deployed AWS frontend instead of the old Vercel URL
+            response.sendRedirect("https://autotradxxebbu-env.eba-vp9dhc3a.eu-north-1.elasticbeanstalk.com/dashboard");
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,8 @@ spring.data.mongodb.database=ClusterDev
 
 upstox.apiKey=97fde129-556b-4a84-9083-9fea5eb53fb0
 upstox.apiSecret=ofye1h1t8e
-upstox.webhookUri= https://backendforautobot-production.up.railway.app/auth
+# URL for OAuth webhook callback now points to AWS deployment
+upstox.webhookUri= https://autotradxxebbu-env.eba-vp9dhc3a.eu-north-1.elasticbeanstalk.com/auth
 logging.level.reactor.netty.http.client=DEBUG
 
 spring.redis.host=localhost   # Redis later; leave like this

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-  "builds": [
-    {
-      "src": "Dockerfile",
-      "use": "@vercel/docker"
-    }
-  ]
-}


### PR DESCRIPTION
## Summary
- replace Vercel/Railway URLs with AWS Elastic Beanstalk domain
- update CORS and webhook configuration for new domain
- remove obsolete Vercel configuration file

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*
- `npm test -- --watch=false` *(fails: No inputs were found in config file /workspace/backendforautobot/frontend/tsconfig.spec.json)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2e8affdf0832faad7ce14ae71b5f7