### PR TITLE
chore: set stable Spring Boot parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.2.5</version>
 		<relativePath/>
 	</parent>
 


### PR DESCRIPTION
## Summary
- use available Spring Boot parent release 3.2.5 instead of 3.4.5

## Testing
- `./mvnw package -DskipTests` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a301de1fec832face69a6f1e0c6f15