### PR TITLE
Add WeatherService with graceful fallback and tests

### DIFF
--- a/src/main/java/com/trader/backend/service/WeatherResponse.java
+++ b/src/main/java/com/trader/backend/service/WeatherResponse.java
@@ -1,0 +1,14 @@
+package com.trader.backend.service;
+
+/**
+ * Simple weather data holder returned by {@link WeatherService}.
+ */
+public record WeatherResponse(double temperature, String description) {
+    /**
+     * Fallback instance used when the remote API cannot be reached
+     * and no cached value is available.
+     */
+    public static WeatherResponse unavailable() {
+        return new WeatherResponse(Double.NaN, "unavailable");
+    }
+}

--- a/src/main/java/com/trader/backend/service/WeatherService.java
+++ b/src/main/java/com/trader/backend/service/WeatherService.java
@@ -1,0 +1,62 @@
+package com.trader.backend.service;
+
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Retrieves weather information from a remote API.  The service keeps the last
+ * successful response in memory and falls back to it whenever the remote call
+ * fails.  If no cached value exists a minimal {@link WeatherResponse#unavailable()}
+ * instance is returned instead.
+ */
+@Service
+public class WeatherService {
+
+    private final WebClient webClient;
+    private final AtomicReference<WeatherResponse> cache = new AtomicReference<>();
+
+    /**
+     * Default constructor used by Spring.  It configures a WebClient pointing to
+     * an open API, but any {@link WebClient} can be supplied for testing.
+     */
+    public WeatherService(WebClient.Builder builder) {
+        this(builder.baseUrl("https://api.open-meteo.com/v1/forecast").build());
+    }
+
+    // Visible for tests
+    WeatherService(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    /**
+     * Fetches current weather for the given coordinates.
+     *
+     * @param lat latitude
+     * @param lon longitude
+     * @return a mono emitting the latest weather information.  In case of an
+     * API error or timeout, the previously cached value (if any) is returned;
+     * otherwise {@link WeatherResponse#unavailable()} is emitted.
+     */
+    public Mono<WeatherResponse> currentWeather(double lat, double lon) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("latitude", lat)
+                        .queryParam("longitude", lon)
+                        .queryParam("current_weather", true)
+                        .build())
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, resp -> Mono.error(new IllegalStateException("API error")))
+                .bodyToMono(WeatherResponse.class)
+                .doOnNext(cache::set)
+                .timeout(Duration.ofSeconds(5))
+                .onErrorResume(ex -> {
+                    WeatherResponse last = cache.get();
+                    return last != null ? Mono.just(last) : Mono.just(WeatherResponse.unavailable());
+                });
+    }
+}

--- a/src/test/java/com/trader/backend/service/WeatherServiceTest.java
+++ b/src/test/java/com/trader/backend/service/WeatherServiceTest.java
@@ -1,0 +1,56 @@
+package com.trader.backend.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link WeatherService}'s fallback behaviour.
+ */
+public class WeatherServiceTest {
+
+    @Test
+    void returnsDefaultWhenApiFails() {
+        WebClient client = WebClient.builder()
+                .exchangeFunction(req -> Mono.error(new RuntimeException("boom")))
+                .build();
+
+        WeatherService svc = new WeatherService(client);
+        WeatherResponse r = svc.currentWeather(0, 0).block();
+
+        assertEquals("unavailable", r.description());
+        assertTrue(Double.isNaN(r.temperature()));
+    }
+
+    @Test
+    void cachesLastSuccessfulResponse() {
+        AtomicInteger calls = new AtomicInteger();
+        ExchangeFunction fn = req -> {
+            if (calls.getAndIncrement() == 0) {
+                return Mono.just(ClientResponse.create(HttpStatus.OK)
+                        .header("Content-Type", "application/json")
+                        .body("{\"temperature\":25.0,\"description\":\"Sunny\"}")
+                        .build());
+            }
+            return Mono.error(new RuntimeException("API down"));
+        };
+
+        WebClient client = WebClient.builder().exchangeFunction(fn).build();
+        WeatherService svc = new WeatherService(client);
+
+        WeatherResponse first = svc.currentWeather(0, 0).block();
+        WeatherResponse second = svc.currentWeather(0, 0).block();
+
+        assertEquals(2, calls.get());
+        assertEquals(25.0, first.temperature());
+        assertEquals("Sunny", first.description());
+        assertEquals(first, second, "Should return cached value after failure");
+    }
+}


### PR DESCRIPTION
## Summary
- add WeatherService that caches last weather response and returns a default when API calls fail
- introduce WeatherResponse data record with an `unavailable` fallback instance
- cover fallback logic with WeatherServiceTest

## Testing
- `./mvnw -q test`


------
https://chatgpt.com/codex/tasks/task_e_68a316cc2ecc832f8dc1f2976723bbe0