### PR TITLE
fix: remove local proxy from maven settings

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,20 +1,5 @@
 <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
-  <proxies>
-    <proxy>
-      <id>http-proxy</id>
-      <active>true</active>
-      <protocol>http</protocol>
-      <host>proxy</host>
-      <port>8080</port>
-    </proxy>
-    <proxy>
-      <id>https-proxy</id>
-      <active>true</active>
-      <protocol>https</protocol>
-      <host>proxy</host>
-      <port>8080</port>
-    </proxy>
-  </proxies>
+  <!-- Proxy configuration removed to avoid failing builds in environments without a local proxy. -->
 </settings>


### PR DESCRIPTION
## Summary
- remove hard-coded proxy settings to allow Maven to reach repositories without a local proxy

## Testing
- `./mvnw test > /tmp/mvn-test.log && tail -n 20 /tmp/mvn-test.log`


------
https://chatgpt.com/codex/tasks/task_e_68a327d7e2fc832f9c2fe8073c121a7e