### PR TITLE
chore: add jitpack repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,20 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>backend</name>
 
-	<properties>
-		<java.version>17</java.version>
-		<!-- align your Protobuf versions here -->
-		<protoc.version>3.21.12</protoc.version>
-	</properties>
+        <properties>
+                <java.version>17</java.version>
+                <!-- align your Protobuf versions here -->
+                <protoc.version>3.21.12</protoc.version>
+        </properties>
+
+        <!-- Additional repositories -->
+        <repositories>
+                <!-- Needed for artifacts like com.github.jai-imageio:jai-imageio-core -->
+                <repository>
+                        <id>jitpack.io</id>
+                        <url>https://jitpack.io</url>
+                </repository>
+        </repositories>
 
 	<dependencies>
 		<!-- Spring + Redis + WebFlux -->


### PR DESCRIPTION
## Summary
- add jitpack repository to resolve dependencies not present in Maven Central

## Testing
- `./mvnw -q package -DskipTests` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a32aebfb1c832f83e773ca4b3484c9