### PR TITLE
Use setup-node in CI to avoid frontend download

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,12 @@ jobs:
           java-version: 17
           distribution: corretto
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Build JAR
-        run: ./mvnw package -DskipTests
+        run: ./mvnw package -DskipTests -DskipFrontend=true -Dskip.installnodenpm=true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Install Node using `actions/setup-node` before Maven build
- Skip frontend build tooling download in Maven command

## Testing
- `./mvnw -q -DskipFrontend=true -Dskip.installnodenpm=true -DskipTests package` *(fails: Network is unreachable: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a32f16c9c0832f8c01990df250a1b5