### PR TITLE
Use setup-node in CI to avoid frontend download

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,8 +20,12 @@ jobs:
           java-version: 17
           distribution: corretto
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
       - name: Build JAR
-        run: ./mvnw package -DskipTests
+        run: ./mvnw package -DskipTests -DskipFrontend=true
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,7 @@
       <configuration>
         <workingDirectory>frontend</workingDirectory>
         <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
+        <skip>${skipFrontend}</skip>
       </configuration>
 
       <executions>


### PR DESCRIPTION
## Summary
- Install Node using `actions/setup-node` before Maven build
- Skip frontend plugin execution when `-DskipFrontend=true`

## Testing
- `./mvnw -q -DskipFrontend=true -DskipTests package` *(fails: Network is unreachable for Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a32f16c9c0832f8c01990df250a1b5