### PR TITLE
Fix frontend-maven-plugin to auto-download Node and NPM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,13 +182,15 @@
         <workingDirectory>frontend</workingDirectory>
         <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
         <skip>${skipFrontend}</skip>
+        <!-- Automatically download a specific Node & NPM version -->
+        <nodeVersion>v18.18.0</nodeVersion>
+        <npmVersion>9.8.1</npmVersion>
       </configuration>
 
       <executions>
         <execution>
           <id>install node and npm</id>
           <goals><goal>install-node-and-npm</goal></goals>
-          <configuration><skip>true</skip></configuration>
         </execution>
         <execution>
           <id>npm install</id>


### PR DESCRIPTION
## Summary
- configure frontend-maven-plugin to download Node and NPM so builds don't fail when Node is missing

## Testing
- `./mvnw -q com.github.eirslett:frontend-maven-plugin:1.13.4:install-node-and-npm` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a33752ac24832fa7b04bd09c6fce80