### PR TITLE
Fix duplicate run in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,8 +25,6 @@ jobs:
           node-version: 20
 
       - name: Build JAR
-        run: ./mvnw package -DskipTests -DskipFrontend=true
-
         run: ./mvnw package -DskipTests -DskipFrontend=true -Dskip.installnodenpm=true
 
 


### PR DESCRIPTION
## Summary
- remove duplicate `run` command in deploy workflow's Build JAR step

## Testing
- `./mvnw -q -DskipFrontend=true test` *(fails: Non-resolvable parent POM for com.trader:backend due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a338bcd2f0832fb52c36f2288ebab0