### PR TITLE
Skip frontend build for offline CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY . .
 
 RUN chmod +x mvnw
 RUN echo "JAVA_HOME is: $JAVA_HOME" && java -version
-RUN ./mvnw clean package -DskipTests
+# Skip building the Angular frontend so Maven doesn't try to download Node
+RUN ./mvnw clean package -DskipTests -DskipFrontend=true
 
 CMD ["java", "-jar", "target/backend-0.0.1-SNAPSHOT.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,8 @@
                 <java.version>17</java.version>
                 <!-- align your Protobuf versions here -->
                 <protoc.version>3.21.12</protoc.version>
+                <!-- Skip frontend build by default to avoid requiring Node during CI -->
+                <skipFrontend>true</skipFrontend>
         </properties>
 
         <!-- Additional repositories -->
@@ -177,21 +179,14 @@
       <artifactId>frontend-maven-plugin</artifactId>
       <version>1.13.4</version>
 
-      <!-- run npm inside frontend/ -->
+      <!-- run npm inside frontend/, relying on system Node instead of downloading -->
       <configuration>
         <workingDirectory>frontend</workingDirectory>
         <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
         <skip>${skipFrontend}</skip>
-        <!-- Automatically download a specific Node & NPM version -->
-        <nodeVersion>v18.18.0</nodeVersion>
-        <npmVersion>9.8.1</npmVersion>
       </configuration>
 
       <executions>
-        <execution>
-          <id>install node and npm</id>
-          <goals><goal>install-node-and-npm</goal></goals>
-        </execution>
         <execution>
           <id>npm install</id>
           <goals><goal>npm</goal></goals>


### PR DESCRIPTION
## Summary
- Skip building the Angular frontend during Maven package to avoid downloading Node
- Default Maven to skip the frontend plugin and rely on system Node when enabled

## Testing
- `./mvnw -q -DskipFrontend=true -DskipTests package` *(fails: Non-resolvable parent POM ... Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a34e180924832f9f1d4065b893df67