### PR TITLE
fix: correct AWS Beanstalk deploy credentials

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,8 +57,8 @@ jobs:
         with:
           application_name: ${{ secrets.EB_APP_NAME }}
           environment_name: ${{ secrets.EB_ENV_NAME }}
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           version_label: github-${{ github.sha }}
           region: ${{ secrets.AWS_REGION }}
-          file: target/*.jar
+          deployment_package: target/*.jar


### PR DESCRIPTION
## Summary
- fix `deploy.yml` AWS credential inputs for Beanstalk deploy action

## Testing
- `./mvnw -q test -DskipFrontend=true -Dskip.installnodenpm=true` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a3854f0500832fa84e4dfdb4c8d7f0