### PR TITLE
Fix Elastic Beanstalk deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,8 @@ jobs:
 
       - name: Build JAR
         run: ./mvnw package -DskipTests -DskipFrontend=true -Dskip.installnodenpm=true
-
+      - name: Locate built JAR
+        run: echo "JAR_FILE=$(ls target/*.jar | head -n 1)" >> $GITHUB_ENV
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -61,4 +62,4 @@ jobs:
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           version_label: github-${{ github.sha }}
           region: ${{ secrets.AWS_REGION }}
-          deployment_package: target/*.jar
+          deployment_package: ${{ env.JAR_FILE }}


### PR DESCRIPTION
## Summary
- resolve wildcard jar path by explicitly locating jar before deploy
- use resolved jar file when deploying to Elastic Beanstalk

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a3897091dc832f9e63e42f5a9d88b0