### PR TITLE
feat: expose AWS redirect URL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ configure the following environment variables:
 
 You can also set `LOG_DIR` to change the directory where local log files are
 stored (defaults to `logs`).
+
+## Authentication
+
+The frontend redirect target used after a successful Upstox login can be
+configured via the `AWS_REDIRECT_URL` environment variable. The current value
+can be retrieved from the backend at `GET /auth/redirect-url`.

--- a/src/main/java/com/trader/backend/controller/AuthController.java
+++ b/src/main/java/com/trader/backend/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.trader.backend.service.UpstoxAuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -22,39 +23,48 @@ public class AuthController {
     private final UpstoxAuthService auth;
     private final ObjectMapper mapper = new ObjectMapper();
 
+    @Value("${AWS_REDIRECT_URL:https://autotradxxebbu-env.eba-vp9dhc3a.eu-north-1.elasticbeanstalk.com/dashboard}")
+    private String awsRedirectUrl;
+
     @GetMapping("/url")
     public Map<String, String> loginUrl() {
         return Map.of("url", auth.buildAuthUrl());
     }
 
- @RequestMapping(value = "", method = RequestMethod.GET)
-public void handleUpstoxRedirect(@RequestParam Map<String, String> qs,
-                                 HttpServletResponse response) {
-    String code = qs.get("code");
-    System.out.println("🔵 Received code: " + code);
-
-    if (code != null && !code.isBlank()) {
-        auth.exchangeCode(code)
-            .doOnSuccess(unused -> {
-                System.out.println("🟢 Exchange success. Starting WebSocket...");
-                auth.initLiveWebSocket();
-            })
-            .doOnError(e -> {
-                System.out.println("🔴 Exchange/WebSocket failed: " + e.getMessage());
-                e.printStackTrace();
-            })
-            .subscribe(); // fire and forget
-
-        try {
-            // Redirect to the deployed AWS frontend instead of the old Vercel URL
-            response.sendRedirect("https://autotradxxebbu-env.eba-vp9dhc3a.eu-north-1.elasticbeanstalk.com/dashboard");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    } else {
-        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    @GetMapping("/redirect-url")
+    public Map<String, String> awsRedirectUrl() {
+        return Map.of("url", awsRedirectUrl);
     }
-}
+
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public void handleUpstoxRedirect(@RequestParam Map<String, String> qs,
+                                     HttpServletResponse response) {
+        String code = qs.get("code");
+        System.out.println("🔵 Received code: " + code);
+
+        if (code != null && !code.isBlank()) {
+            auth.exchangeCode(code)
+                .doOnSuccess(unused -> {
+                    System.out.println("🟢 Exchange success. Starting WebSocket...");
+                    auth.initLiveWebSocket();
+                })
+                .doOnError(e -> {
+                    System.out.println("🔴 Exchange/WebSocket failed: " + e.getMessage());
+                    e.printStackTrace();
+                })
+                .subscribe(); // fire and forget
+
+            try {
+                // Redirect to the deployed AWS frontend; configurable via environment variable
+                response.sendRedirect(awsRedirectUrl);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        }
+    }
+
     @PostMapping("/exchange")
     public Mono<ResponseEntity<Object>> exchangeCode(@RequestParam("code") String code) {
         return auth.exchangeCode(code)
@@ -88,10 +98,10 @@ public void handleUpstoxRedirect(@RequestParam Map<String, String> qs,
         return Mono.empty();
     }
 
-@GetMapping("/token-status")
-public ResponseEntity<Map<String, Object>> getTokenStatus() {
-    return auth.getTokenStatus();
-}
+    @GetMapping("/token-status")
+    public ResponseEntity<Map<String, Object>> getTokenStatus() {
+        return auth.getTokenStatus();
+    }
 
     public record WebhookPayload(
             String client_id,


### PR DESCRIPTION
## Summary
- expose configurable AWS redirect URL via `/auth/redirect-url`
- reuse AWS_REDIRECT_URL for OAuth redirect
- document AWS_REDIRECT_URL environment variable

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a45f3bd990832fb0168bda73a3320e