### PR TITLE
Fix logback XML and log startup token

### DIFF
--- a/src/main/java/com/trader/backend/config/UpstoxTokenBootstrap.java
+++ b/src/main/java/com/trader/backend/config/UpstoxTokenBootstrap.java
@@ -1,12 +1,13 @@
 package com.trader.backend.config;
 
 import com.upstox.ApiClient;
-import com.upstox.auth.OAuth;
 import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@Slf4j
 public class UpstoxTokenBootstrap {
 
     private final ApiClient apiClient;
@@ -22,7 +23,7 @@ public class UpstoxTokenBootstrap {
     public void init() {
         // safest way: set default header directly
         apiClient.addDefaultHeader("Authorization", "Bearer " + accessToken);
-        System.out.println("✅  Sandbox access-token attached as default header");
+        log.info("✅ Sandbox access-token attached as default header: {}", accessToken);
     }
 
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -26,7 +26,7 @@
     <springProperty scope="context" name="LOG_AGGREGATOR_HOST" source="LOG_AGGREGATOR_HOST"/>
     <springProperty scope="context" name="LOG_AGGREGATOR_PORT" source="LOG_AGGREGATOR_PORT"/>
 
-    <if condition='property("LOG_AGGREGATOR_HOST").length() > 0 && property("LOG_AGGREGATOR_PORT").length() > 0'>
+    <if condition='property("LOG_AGGREGATOR_HOST").length() > 0 &amp;&amp; property("LOG_AGGREGATOR_PORT").length() > 0'>
         <then>
             <appender name="SOCKET" class="ch.qos.logback.classic.net.SocketAppender">
                 <remoteHost>${LOG_AGGREGATOR_HOST}</remoteHost>
@@ -39,7 +39,7 @@
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
         <appender-ref ref="FILE"/>
-        <if condition='property("LOG_AGGREGATOR_HOST").length() > 0 && property("LOG_AGGREGATOR_PORT").length() > 0'>
+        <if condition='property("LOG_AGGREGATOR_HOST").length() > 0 &amp;&amp; property("LOG_AGGREGATOR_PORT").length() > 0'>
             <then>
                 <appender-ref ref="SOCKET"/>
             </then>


### PR DESCRIPTION
## Summary
- escape ampersands in logback-spring.xml conditions to avoid XML parse errors
- log the configured access token at startup using SLF4J

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to jitpack.io (https://jitpack.io): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a2ea9778832f95d7491d634392c2