### PR TITLE
Fix Upstox webhook property

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.data.mongodb.database=ClusterDev
 upstox.apiKey=97fde129-556b-4a84-9083-9fea5eb53fb0
 upstox.apiSecret=ofye1h1t8e
 # URL for OAuth webhook callback now points to AWS deployment
-upstox.redirect-url=https://autotradebot-env.eba-adnie9a5.eu-north-1.elasticbeanstalk.com/auth
+upstox.webhookUri=https://autotradebot-env.eba-adnie9a5.eu-north-1.elasticbeanstalk.com/auth
 logging.level.reactor.netty.http.client=DEBUG
 
 spring.redis.host=localhost   # Redis later; leave like this


### PR DESCRIPTION
## Summary
- use `upstox.webhookUri` property to match service configuration

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bd9f8f3c832fb00077f2a099f2c9