### PR TITLE
Handle missing Upstox credentials gracefully

### DIFF
--- a/src/main/java/com/trader/backend/config/InfluxConfig.java
+++ b/src/main/java/com/trader/backend/config/InfluxConfig.java
@@ -4,28 +4,31 @@ import com.influxdb.client.InfluxDBClient;
 import com.influxdb.client.InfluxDBClientFactory;
 import com.influxdb.client.WriteApiBlocking;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class InfluxConfig {
 
-    @Value("${influx.url}")
+    @Value("${influx.url:}")
     private String url;
 
-    @Value("${influx.token}")
+    @Value("${influx.token:}")
     private String token;
 
-    @Value("${influx.org}")
+    @Value("${influx.org:}")
     private String org;
 
-    @Value("${influx.bucket}")
+    @Value("${influx.bucket:}")
     private String bucket;
 
     /**
      * Create a singleton InfluxDBClient that knows your URL, token, org & bucket.
      */
     @Bean
+    @ConditionalOnProperty(prefix = "influx", name = "url")
     public InfluxDBClient influxDBClient() {
         // note: token must be passed as char[] for security
         return InfluxDBClientFactory.create(url, token.toCharArray(), org, bucket);
@@ -35,6 +38,7 @@ public class InfluxConfig {
      * Expose the WriteApiBlocking so you can inject it into your service.
      */
     @Bean
+    @ConditionalOnBean(InfluxDBClient.class)
     public WriteApiBlocking writeApi(InfluxDBClient influxDBClient) {
         return influxDBClient.getWriteApiBlocking();
     }

--- a/src/main/java/com/trader/backend/config/UpstoxTokenBootstrap.java
+++ b/src/main/java/com/trader/backend/config/UpstoxTokenBootstrap.java
@@ -12,7 +12,7 @@ public class UpstoxTokenBootstrap {
 
     private final ApiClient apiClient;
 
-    @Value("${upstox.accessToken}")
+    @Value("${upstox.accessToken:}")
     private String accessToken;
 
     public UpstoxTokenBootstrap(ApiClient apiClient) {
@@ -21,9 +21,13 @@ public class UpstoxTokenBootstrap {
 
     @PostConstruct
     public void init() {
-        // safest way: set default header directly
-        apiClient.addDefaultHeader("Authorization", "Bearer " + accessToken);
-        log.info("✅ Sandbox access-token attached as default header: {}", accessToken);
+        // Only attach the header if a token is actually provided
+        if (accessToken != null && !accessToken.isBlank()) {
+            apiClient.addDefaultHeader("Authorization", "Bearer " + accessToken);
+            log.info("✅ Sandbox access-token attached as default header: {}", accessToken);
+        } else {
+            log.warn("⚠️ upstox.accessToken not set; skipping default Authorization header");
+        }
     }
 
 }

--- a/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -49,13 +49,13 @@ public class UpstoxAuthService {
         this.liveFeedService = liveFeedService;
     }
 
-    @Value("${upstox.apiKey}")
+    @Value("${upstox.apiKey:}")
     private String apiKey;
 
-    @Value("${upstox.apiSecret}")
+    @Value("${upstox.apiSecret:}")
     private String apiSecret;
 
-    @Value("${upstox.webhookUri}")
+    @Value("${upstox.webhookUri:}")
     private String webhookUri;
 
     private final AtomicReference<String> accessToken = new AtomicReference<>();
@@ -64,6 +64,10 @@ public class UpstoxAuthService {
     private final AtomicReference<String> currentToken = new AtomicReference<>();
 
     public Mono<Void> exchangeCode(String code) {
+        if (apiKey.isBlank() || apiSecret.isBlank() || webhookUri.isBlank()) {
+            return Mono.error(new IllegalStateException("Upstox credentials not configured"));
+        }
+
         return webClient.post()
                 .uri("/login/authorization/token")
                 .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
@@ -134,6 +138,10 @@ public class UpstoxAuthService {
     }
 }
     public String buildAuthUrl() {
+        if (apiKey.isBlank() || webhookUri.isBlank()) {
+            throw new IllegalStateException("Upstox credentials not configured");
+        }
+
         return UriComponentsBuilder
                 .fromUriString("https://api.upstox.com/v2/login/authorization/dialog")
                 .queryParam("response_type", "code")


### PR DESCRIPTION
## Summary
- Avoid failing startup when `upstox.accessToken` is missing by skipping header injection
- Default Upstox API credentials to blanks and guard usage so app boots without them

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c10bf7a4832f9ced9a38b52c0d34