### PR TITLE
Use fixed port 8080 for Spring Boot server

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=backend
-server.port=${PORT:5000}
+server.port=8080
 # MongoDB configuration
 spring.data.mongodb.uri=mongodb+srv://imanuelsha:Johnwick007@clusterdev.nzpqse9.mongodb.net/?retryWrites=true&w=majority&ssl=true
 spring.data.mongodb.database=ClusterDev


### PR DESCRIPTION
## Summary
- Configure Spring Boot server to listen on port 8080

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to jitpack.io: Network is unreachable)*
- `./mvnw -q spring-boot:run` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5663ebc8c832fafc59d9ca9dce861