### PR TITLE
Configure Elastic Beanstalk proxy port for Spring Boot

### DIFF
--- a/.ebextensions/00_nginx.config
+++ b/.ebextensions/00_nginx.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:container:tomcat:jvmoptions:
+    ProxyPort: 8080


### PR DESCRIPTION
## Summary
- route Elastic Beanstalk traffic to port 8080 via nginx config

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a59adb8bc8832fac3158a6a985a2aa