### PR TITLE
fix: remove invalid Elastic Beanstalk JVM options

### DIFF
--- a/.ebextensions/00_nginx.config
+++ b/.ebextensions/00_nginx.config
@@ -1,3 +1,0 @@
-option_settings:
-  aws:elasticbeanstalk:container:tomcat:jvmoptions:
-    ProxyPort: 5000


### PR DESCRIPTION
## Summary
- remove obsolete `.ebextensions` config that set unknown `JVMOptions`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e9dd35f4832fb1c80cb19f98fdfb