### PR TITLE
Add ping health check endpoint

### DIFF
--- a/src/main/java/com/trader/backend/controller/PingController.java
+++ b/src/main/java/com/trader/backend/controller/PingController.java
@@ -1,0 +1,13 @@
+package com.trader.backend.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PingController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "Spring Boot is alive";
+    }
+}


### PR DESCRIPTION
## Summary
- add simple ping controller responding with `Spring Boot is alive` for `/ping`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a6c0721810832f83efb7e24dea7d0d