### PR TITLE
Configure Railway port and health endpoint

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java -Dserver.port=$PORT -jar backend-0.0.1-SNAPSHOT.jar
+web: java -jar backend-0.0.1-SNAPSHOT.jar

--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis-reactive</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-actuator</artifactId>
+                </dependency>
 
 		<!-- Upstox SDK -->
 		<dependency>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,10 @@ server.port=${PORT:8080}
 server.address=0.0.0.0
 spring.main.web-application-type=servlet
 
+# Expose only the health endpoint for Railway
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=never
+
 # Frontend configuration
 FRONTEND_ORIGIN=https://frontendfortheautobot-7u7woqq2m-johnwicks-projects-025aea65.vercel.app
 FRONTEND_REDIRECT_URL=https://frontendfortheautobot-7u7woqq2m-johnwicks-projects-025aea65.vercel.app/dashboard


### PR DESCRIPTION
## Summary
- read server port from the `PORT` environment variable with a default of 8080
- expose the Spring Boot actuator health endpoint for Railway
- remove explicit `-Dserver.port=$PORT` from the Procfile and add actuator dependency

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3b28b8ec832fb164afcdaa05d69d