### PR TITLE
Gracefully handle missing Upstox token

### DIFF
--- a/src/main/java/com/trader/backend/config/WebClientConfig.java
+++ b/src/main/java/com/trader/backend/config/WebClientConfig.java
@@ -2,15 +2,24 @@ package com.trader.backend.config;
 
 
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class WebClientConfig {
 
     @Bean
+    @Primary
     public WebClient webClient() {
         return WebClient.builder().build();
+    }
+
+    @Bean
+    @Qualifier("weatherClient")
+    public WebClient weatherClient(WebClient.Builder builder) {
+        return builder.baseUrl("https://api.open-meteo.com/v1/forecast").build();
     }
 }

--- a/src/main/java/com/trader/backend/service/WeatherService.java
+++ b/src/main/java/com/trader/backend/service/WeatherService.java
@@ -1,5 +1,7 @@
 package com.trader.backend.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -15,23 +17,11 @@ import java.util.concurrent.atomic.AtomicReference;
  * instance is returned instead.
  */
 @Service
+@RequiredArgsConstructor
 public class WeatherService {
 
-    private final WebClient webClient;
+    private final @Qualifier("weatherClient") WebClient webClient;
     private final AtomicReference<WeatherResponse> cache = new AtomicReference<>();
-
-    /**
-     * Default constructor used by Spring.  It configures a WebClient pointing to
-     * an open API, but any {@link WebClient} can be supplied for testing.
-     */
-    public WeatherService(WebClient.Builder builder) {
-        this(builder.baseUrl("https://api.open-meteo.com/v1/forecast").build());
-    }
-
-    // Visible for tests
-    WeatherService(WebClient webClient) {
-        this.webClient = webClient;
-    }
 
     /**
      * Fetches current weather for the given coordinates.


### PR DESCRIPTION
## Summary
- Refactor WeatherService to use constructor injection with a dedicated WebClient bean
- Start live feed after successful OAuth and add token checks to streaming methods
- Provide weather WebClient configuration and handle Upstox token absence gracefully

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM from jitpack.io)*
- `./mvnw -q spring-boot:run` *(fails: Non-resolvable parent POM from jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4d0d9b50832f92e1a3ae5e46e5d3