### PR TITLE
Throttle LTP logging and save full ticks to Influx

### DIFF
--- a/src/main/java/com/trader/backend/events/LtpEvent.java
+++ b/src/main/java/com/trader/backend/events/LtpEvent.java
@@ -1,0 +1,8 @@
+package com.trader.backend.events;
+
+import java.time.Instant;
+
+/**
+ * Lightweight LTP event published internally for potential UI consumers.
+ */
+public record LtpEvent(String instrumentKey, double ltp, Instant timestamp) {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -51,4 +51,20 @@ spring.autoconfigure.exclude=\
   org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration,\
   org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
 
+# --- LTP log throttling ---
+ltp.log.enabled=true
+ltp.log.interval.ms=2000
+ltp.log.min.price.delta=0.5
+
+# --- Influx summary ---
+influx.summary.interval.ms=15000
+
+# --- Reduce package noise ---
+logging.level.org.mongodb.driver=WARN
+logging.level.reactor.netty=WARN
+logging.level.io.netty=WARN
+logging.level.okhttp3=WARN
+logging.level.com.upstox=WARN
+logging.level.root=INFO
+
 


### PR DESCRIPTION
## Summary
- add configurable LTP logging with per-instrument throttling
- write every tick to InfluxDB using separate FUT/OPT measurements and periodic summaries
- expose internal `LtpEvent` stream for future UI consumers

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ac977b9adc832f9d9ddf18cd15a14b