### PR TITLE
Add market data UI endpoints and scoped CORS

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -15,23 +15,21 @@ import java.util.List;
 @EnableWebMvc
 public class CorsConfig {
 
-    @Value("${FRONTEND_ORIGIN:https://frontendfortheautobot-7u7woqq2m-johnwicks-projects-025aea65.vercel.app}")
-    private String frontendOrigin;
+    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app}")
+    private String allowedOrigins;
 
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(true);
-
-        // Allow the deployed frontend and local development
-        config.setAllowedOrigins(List.of(frontendOrigin, "http://localhost:4200"));
-
-        config.setAllowedHeaders(List.of("*"));
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowCredentials(false);
+        config.setAllowedOrigins(List.of(allowedOrigins));
+        config.setAllowedHeaders(List.of("Content-Type", "Authorization"));
+        config.setAllowedMethods(List.of("GET"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/auth/url", config);
         source.registerCorsConfiguration("/auth/status", config);
+        source.registerCorsConfiguration("/md/candles", config);
+        source.registerCorsConfiguration("/md/stream", config);
 
         return new CorsFilter(source);
     }

--- a/src/main/java/com/trader/backend/controller/MdController.java
+++ b/src/main/java/com/trader/backend/controller/MdController.java
@@ -1,0 +1,65 @@
+package com.trader.backend.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.trader.backend.service.CandleService;
+import com.trader.backend.service.CandleService.CandleResponse;
+import com.trader.backend.service.LiveFeedService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.codec.ServerSentEvent;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@RestController
+@RequestMapping("/md")
+@RequiredArgsConstructor
+public class MdController {
+    private final CandleService candleService;
+    private final LiveFeedService liveFeedService;
+
+    @GetMapping("/candles")
+    public Mono<List<CandleResponse>> candles(@RequestParam("instrumentKey") List<String> instrumentKeys,
+                                             @RequestParam(value = "tf", defaultValue = "1m") String tf,
+                                             @RequestParam(value = "lookback", defaultValue = "120") int lookback) {
+        if (instrumentKeys == null || instrumentKeys.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "instrumentKey required");
+        }
+        if (!Set.of("1m","3m","5m","15m").contains(tf)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "invalid tf");
+        }
+        int lb = Math.min(Math.max(lookback,1), 720);
+        return candleService.fetchCandles(instrumentKeys, tf, lb);
+    }
+
+    @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<ServerSentEvent<String>> stream(@RequestParam(value = "instrumentKey", required = false) List<String> keys,
+                                                ServerHttpResponse response) {
+        response.getHeaders().set(HttpHeaders.CACHE_CONTROL, "no-cache");
+        Flux<JsonNode> flux = liveFeedService.stream();
+        if (keys != null && !keys.isEmpty()) {
+            Set<String> set = new HashSet<>(keys);
+            flux = flux.filter(j -> set.contains(j.path("instrumentKey").asText()));
+        }
+        Flux<ServerSentEvent<String>> ticks = flux
+                .onBackpressureDrop()
+                .map(j -> ServerSentEvent.builder(j.toString()).event("tick").build());
+
+        Flux<ServerSentEvent<String>> heartbeat = Flux.interval(Duration.ofSeconds(15))
+                .map(i -> ServerSentEvent.<String>builder().comment("hb").build());
+
+        return Flux.merge(ticks, heartbeat);
+    }
+}

--- a/src/main/java/com/trader/backend/service/CandleService.java
+++ b/src/main/java/com/trader/backend/service/CandleService.java
@@ -1,0 +1,95 @@
+package com.trader.backend.service;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.QueryApi;
+import com.influxdb.query.FluxRecord;
+import com.influxdb.query.FluxTable;
+import com.trader.backend.entity.NseInstrument;
+import com.trader.backend.repository.NseInstrumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class CandleService {
+    private final InfluxDBClient influxDBClient;
+    private final NseInstrumentRepository repo;
+
+    private static final Set<String> ALLOWED_TF = Set.of("1m","3m","5m","15m");
+
+    public Mono<List<CandleResponse>> fetchCandles(List<String> keys, String tf, int lookback) {
+        if (keys == null || keys.isEmpty()) {
+            return Mono.just(List.of());
+        }
+        if (!ALLOWED_TF.contains(tf)) {
+            return Mono.error(new IllegalArgumentException("Unknown timeframe"));
+        }
+        int lb = Math.min(Math.max(lookback,1), 720);
+        Duration unit = switch (tf) {
+            case "3m" -> Duration.ofMinutes(3);
+            case "5m" -> Duration.ofMinutes(5);
+            case "15m" -> Duration.ofMinutes(15);
+            default -> Duration.ofMinutes(1);
+        };
+        String start = "-" + (unit.toMinutes()*lb) + "m";
+        QueryApi queryApi = influxDBClient.getQueryApi();
+        String bucket = influxDBClient.getOptions().getBucket();
+        return Flux.fromIterable(keys)
+                .flatMap(key -> Mono.fromCallable(() -> queryForInstrument(queryApi, bucket, key, tf, start)))
+                .collectList();
+    }
+
+    private CandleResponse queryForInstrument(QueryApi queryApi, String bucket, String key, String tf, String start) {
+        Optional<NseInstrument> opt = repo.findById(key);
+        if (opt.isEmpty()) {
+            return new CandleResponse(key, tf, List.of());
+        }
+        String measurement = "FUT".equalsIgnoreCase(opt.get().getInstrumentType()) ?
+                "nifty_fut_ticks" : "nifty_option_ticks";
+
+        String fluxTemplate = """
+price = from(bucket: "%s")
+  |> range(start: %s)
+  |> filter(fn: (r) => r._measurement == "%s" and r.instrumentKey == "%s" and r._field == "ltp")
+  |> aggregateWindow(every: %s, fn: (tables=<-) => tables |> ohlc())
+  |> rename(columns: {open: "o", high: "h", low: "l", close: "c"})
+  |> keep(columns: ["_time","o","h","l","c"])
+vol = from(bucket: "%s")
+  |> range(start: %s)
+  |> filter(fn: (r) => r._measurement == "%s" and r.instrumentKey == "%s" and r._field == "volume")
+  |> aggregateWindow(every: %s, fn: sum)
+  |> rename(columns: {_value: "v"})
+  |> keep(columns: ["_time","v"])
+join(tables: {price: price, vol: vol}, on: ["_time"])
+  |> sort(columns: ["_time"])
+""";
+
+        String flux = String.format(fluxTemplate,
+                bucket, start, measurement, key, tf,
+                bucket, start, measurement, key, tf);
+
+        List<FluxTable> tables = queryApi.query(flux);
+        List<Candle> candles = new ArrayList<>();
+        for (FluxTable table : tables) {
+            for (FluxRecord rec : table.getRecords()) {
+                Instant t = (Instant) rec.getValue("_time");
+                Double o = (Double) rec.getValue("o");
+                Double h = (Double) rec.getValue("h");
+                Double l = (Double) rec.getValue("l");
+                Double c = (Double) rec.getValue("c");
+                Number v = (Number) rec.getValue("v");
+                candles.add(new Candle(t.toString(), o, h, l, c, v == null ? 0L : v.longValue()));
+            }
+        }
+        return new CandleResponse(key, tf, candles);
+    }
+
+    public record CandleResponse(String instrumentKey, String tf, List<Candle> candles) {}
+    public record Candle(String t, double o, double h, double l, double c, long v) {}
+}

--- a/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -233,7 +233,7 @@ public class UpstoxAuthService {
 
         Map<String, Object> m = new HashMap<>();
         m.put("connected", connected);
-        m.put("expiresAt", exp);
+        m.put("expiresAt", (connected && exp > 0) ? Instant.ofEpochSecond(exp).toString() : null);
         m.put("remainingSeconds", connected ? exp - now : 0);
         return Mono.just(m);
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,3 +68,7 @@ logging.level.com.upstox=WARN
 logging.level.root=INFO
 
 
+
+# --- UI CORS ---
+cors.allowedOrigins=https://frontendfortheautobot.vercel.app
+


### PR DESCRIPTION
## Summary
- add read-only /md/candles and /md/stream endpoints for UI
- expose auth token status with ISO expiry
- tighten CORS to specific origins and paths

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68acd2886df4832fbd56aedd2884ce46