### PR TITLE
Fix CandleService for InfluxDB v6 and add numeric casting tests

### DIFF
--- a/src/test/java/com/trader/backend/service/CandleServiceTest.java
+++ b/src/test/java/com/trader/backend/service/CandleServiceTest.java
@@ -1,0 +1,23 @@
+package com.trader.backend.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for numeric casting helpers in {@link CandleService}.
+ */
+class CandleServiceTest {
+
+    @Test
+    void testToDoubleAndLong() {
+        assertEquals(1.5d, CandleService.toDouble(1.5d));
+        assertEquals(2.0d, CandleService.toDouble(2));
+        assertNull(CandleService.toDouble(null));
+
+        assertEquals(5L, CandleService.toLong(5));
+        assertEquals(7L, CandleService.toLong(7.8d));
+        assertNull(CandleService.toLong(null));
+    }
+}
+


### PR DESCRIPTION
## Summary
- inject Influx org and bucket properties instead of relying on client options
- rebuild candle aggregation using new Flux queries and safe `getValueByKey` parsing
- add helpers and tests for numeric casting and null safety

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68acd777e840832f97454051a51dcaf3