### PR TITLE
Add market selection endpoint and tighten CORS rules

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -9,25 +9,27 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import java.util.Arrays;
 import java.util.List;
 @ComponentScan
 @Configuration
 @EnableWebMvc
 public class CorsConfig {
 
-    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app}")
+    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app,http://localhost:4200}")
     private String allowedOrigins;
 
     @Bean
     public CorsFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(false);
-        config.setAllowedOrigins(List.of(allowedOrigins));
-        config.setAllowedHeaders(List.of("Content-Type", "Authorization"));
-        config.setAllowedMethods(List.of("GET", "POST", "OPTIONS"));
+        config.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
+        config.setAllowedHeaders(List.of("Content-Type"));
+        config.setAllowedMethods(List.of("GET"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
+        List<String> paths = List.of("/auth/status", "/md/candles", "/md/stream", "/md/selection");
+        paths.forEach(p -> source.registerCorsConfiguration(p, config));
 
         return new CorsFilter(source);
     }


### PR DESCRIPTION
## Summary
- expose `/md/selection` endpoint to deliver main futures and option keys
- restrict CORS to GET requests from the dashboard and local dev origins

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, network is unreachable to jitpack.io)*

------
https://chatgpt.com/codex/tasks/task_e_68ad5f917630832fb1827109606d8bf1