### PR TITLE
Redirect OAuth flow to configurable production dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ stored (defaults to `logs`).
 
 ## Authentication
 
-The frontend redirect target used after a successful Upstox login can be
-configured via the `FRONTEND_REDIRECT_URL` environment variable. By default this
-points to the deployed Vercel frontend. The current value can be retrieved from
-the backend at `GET /auth/redirect-url`.
+The frontend dashboard URL used after a successful Upstox login can be
+configured via the `FRONTEND_DASHBOARD_URL` environment variable (property
+`frontend.dashboard-url`). By default this points to the deployed Vercel
+frontend. The current value can be retrieved from the backend at
+`GET /auth/redirect-url`.
 
-For CORS, set `FRONTEND_ORIGIN` to your frontend URL. It defaults to the deployed
-Vercel domain, while `http://localhost:4200` remains allowed for local
-development.
+For CORS, adjust the `cors.allowedOrigins` property if you need to allow
+additional origins. By default it allows the deployed Vercel domain and
+`http://localhost:4200` for local development.

--- a/src/main/java/com/trader/backend/controller/AuthController.java
+++ b/src/main/java/com/trader/backend/controller/AuthController.java
@@ -19,8 +19,8 @@ public class AuthController {
 
     private final UpstoxAuthService auth;
 
-    @Value("${FRONTEND_REDIRECT_URL:https://frontendfortheautobot-7u7woqq2m-johnwicks-projects-025aea65.vercel.app/dashboard}")
-    private String frontendRedirectUrl;
+    @Value("${frontend.dashboard-url}")
+    private String frontendDashboardUrl;
 
     /** Return the OAuth dialog URL for the frontend. */
     @GetMapping("/url")
@@ -30,7 +30,7 @@ public class AuthController {
 
     @GetMapping("/redirect-url")
     public Map<String, String> redirectUrl() {
-        return Map.of("url", frontendRedirectUrl);
+        return Map.of("url", frontendDashboardUrl);
     }
 
     /** Endpoint used by the Upstox redirect after login. */
@@ -47,7 +47,7 @@ public class AuthController {
                 log.error("Token exchange failed", e);
             }
             try {
-                response.sendRedirect(frontendRedirectUrl);
+                response.sendRedirect(frontendDashboardUrl);
             } catch (Exception e) {
                 log.error("Failed to redirect to frontend", e);
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,8 +10,7 @@ management.endpoints.web.exposure.include=health
 management.endpoint.health.show-details=never
 
 # Frontend configuration
-FRONTEND_ORIGIN=https://frontendfortheautobot-7u7woqq2m-johnwicks-projects-025aea65.vercel.app
-FRONTEND_REDIRECT_URL=https://frontendfortheautobot-7u7woqq2m-johnwicks-projects-025aea65.vercel.app/dashboard
+frontend.dashboard-url=${FRONTEND_DASHBOARD_URL:https://frontendfortheautobot.vercel.app/dashboard}
 
 # MongoDB configuration
 spring.data.mongodb.uri=mongodb+srv://imanuelsha:Johnwick007@clusterdev.nzpqse9.mongodb.net/?retryWrites=true&w=majority&ssl=true


### PR DESCRIPTION
## Summary
- Redirect `/auth` exchanges to a configurable frontend dashboard URL instead of a hard-coded preview domain
- Add `frontend.dashboard-url` property with `FRONTEND_DASHBOARD_URL` override and document the new variable
- Ensure CORS configuration allows the production frontend domain

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adaec6978c832fbe6b091d9443b95b