### PR TITLE
Expose LTP SSE stream and enable CORS for market data

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -28,7 +28,12 @@ public class CorsConfig {
         config.setAllowedMethods(List.of("GET"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        List<String> paths = List.of("/auth/url", "/auth/status");
+        List<String> paths = List.of(
+                "/auth/url",
+                "/auth/status",
+                "/md/selection",
+                "/md/stream"
+        );
         paths.forEach(p -> source.registerCorsConfiguration(p, config));
 
         return new CorsFilter(source);


### PR DESCRIPTION
## Summary
- stream LTP ticks over SSE with instrument key, timestamp, and price
- allow frontend origin on market data selection and stream endpoints

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ade64249ec832f9078ac693f11932b