### PR TITLE
Add market hours awareness with cached LTP

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -29,10 +29,11 @@ public class CorsConfig {
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         List<String> paths = List.of(
-                "/auth/url",
-                "/auth/status",
+                "/auth/**",
                 "/md/selection",
-                "/md/stream"
+                "/md/candles",
+                "/md/stream",
+                "/md/last-ltp"
         );
         paths.forEach(p -> source.registerCorsConfiguration(p, config));
 

--- a/src/main/java/com/trader/backend/service/MarketHours.java
+++ b/src/main/java/com/trader/backend/service/MarketHours.java
@@ -1,0 +1,45 @@
+package com.trader.backend.service;
+
+import java.time.*;
+
+/**
+ * Utility for India market hours. Assumes trading days are Monday–Friday
+ * and ignores exchange holidays.
+ */
+public class MarketHours {
+    private static final ZoneId IST = ZoneId.of("Asia/Kolkata");
+    private static final LocalTime OPEN = LocalTime.of(9, 15);
+    private static final LocalTime CLOSE = LocalTime.of(15, 30);
+
+    /**
+     * Returns true if the given instant falls within regular market hours
+     * (09:15–15:30 IST, Monday–Friday).
+     */
+    public static boolean isOpen(Instant now) {
+        ZonedDateTime z = now.atZone(IST);
+        DayOfWeek dow = z.getDayOfWeek();
+        if (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY) {
+            return false;
+        }
+        LocalTime t = z.toLocalTime();
+        return !t.isBefore(OPEN) && !t.isAfter(CLOSE);
+    }
+
+    /**
+     * Returns the next market open instant strictly after the given instant.
+     * Holidays are ignored.
+     */
+    public static Instant nextOpenAfter(Instant now) {
+        ZonedDateTime z = now.atZone(IST);
+        ZonedDateTime candidate = z.with(OPEN);
+        if (!z.toLocalTime().isBefore(OPEN)) {
+            candidate = candidate.plusDays(1);
+        }
+        while (candidate.getDayOfWeek() == DayOfWeek.SATURDAY ||
+               candidate.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            candidate = candidate.plusDays(1);
+        }
+        return candidate.toInstant();
+    }
+}
+

--- a/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -126,7 +126,6 @@ public class UpstoxAuthService {
                     saveTokenBundle(at, refreshToken.get(), exp);
                     authEvents.tryEmitNext(AuthEvent.READY);
                     log.info("✅ access_token saved (expires {})", exp > 0 ? Instant.ofEpochSecond(exp) : "unknown");
-                    liveFeed.initLiveWebSocket();
                 })
                 .then();
     }


### PR DESCRIPTION
## Summary
- introduce `MarketHours` helper to compute India market open periods
- cache latest tick per instrument and schedule live feed start only during open hours
- expose `/md/last-ltp` and enhance `/md/stream` for market closed status with heartbeats
- expand CORS to new endpoints

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to jitpack.io (https://jitpack.io): Network is unreachable and 'parent.relativePath' points at no local POM @ line 8, column 10)*

------
https://chatgpt.com/codex/tasks/task_e_68adf1db2a54832f815fe17ed41ec24e