### PR TITLE
Use LinkedHashMap for JSON responses

### DIFF
--- a/src/main/java/com/trader/backend/controller/AuthController.java
+++ b/src/main/java/com/trader/backend/controller/AuthController.java
@@ -10,6 +10,7 @@ import reactor.core.publisher.Mono;
 
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Map;
+import java.util.LinkedHashMap;
 
 @RestController
 @RequestMapping("/auth")
@@ -25,12 +26,16 @@ public class AuthController {
     /** Return the OAuth dialog URL for the frontend. */
     @GetMapping("/url")
     public Map<String, String> loginUrl() {
-        return Map.of("url", auth.buildAuthUrl());
+        Map<String, String> body = new LinkedHashMap<>();
+        body.put("url", auth.buildAuthUrl());
+        return body;
     }
 
     @GetMapping("/redirect-url")
     public Map<String, String> redirectUrl() {
-        return Map.of("url", frontendDashboardUrl);
+        Map<String, String> body = new LinkedHashMap<>();
+        body.put("url", frontendDashboardUrl);
+        return body;
     }
 
     /** Endpoint used by the Upstox redirect after login. */

--- a/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -269,7 +270,7 @@ public class UpstoxAuthService {
         String token = accessToken.get();
         if (token == null) {
             log.warn("Access-token not ready. Hit /auth/exchange first.");
-            return Mono.just(Map.of());
+            return Mono.just(new LinkedHashMap<>());
         }
 
         return webClient.get()


### PR DESCRIPTION
## Summary
- replace `Map.of` usage with explicit `LinkedHashMap` building to handle possible null values
- clean up auth-related controller helpers and service to avoid intersection type issues

## Testing
- `mvn -q -DskipTests -DskipFrontend=true clean package` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68adf55cef9c832fa632b87d7e65c78f