### PR TITLE
Add /md/ltp endpoint for NIFTY futures

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -16,7 +16,7 @@ import java.util.List;
 @EnableWebMvc
 public class CorsConfig {
 
-    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app}")
+    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app,http://localhost:4200}")
     private String allowedOrigins;
 
     @Bean
@@ -33,7 +33,8 @@ public class CorsConfig {
                 "/md/selection",
                 "/md/candles",
                 "/md/stream",
-                "/md/last-ltp"
+                "/md/last-ltp",
+                "/md/ltp"
         );
         paths.forEach(p -> source.registerCorsConfiguration(p, config));
 

--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -87,6 +87,10 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
         return Optional.ofNullable(lastLtp.get(key));
     }
 
+    public Double getLatestLtp(String key) {
+        return lastQuote(key).map(LatestQuote::ltp).orElse(null);
+    }
+
     public Set<String> cachedKeys() {
         return lastLtp.keySet();
     }

--- a/src/main/java/com/trader/backend/service/SelectionService.java
+++ b/src/main/java/com/trader/backend/service/SelectionService.java
@@ -1,0 +1,14 @@
+package com.trader.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SelectionService {
+    private final NseInstrumentService nseInstrumentService;
+
+    public String getMainFutureKey() {
+        return nseInstrumentService.nearestNiftyFutureKey().orElse(null);
+    }
+}


### PR DESCRIPTION
## Summary
- add `/md/ltp` endpoint to expose latest NIFTY future LTP with InfluxDB fallback
- introduce `SelectionService` and helper methods for fetching LTPs
- allow CORS GET access to `/md/ltp` from production and local origins

## Testing
- `./mvnw clean package -DskipTests -DskipFrontend=true -s /tmp/settings.xml` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aef8b451e8832f99be1aabe7dda8a0