### PR TITLE
feat: expose LTP endpoint and stabilize instrument refresh

### DIFF
--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -564,7 +564,6 @@ JsonNode ltpNode = tick.path("feeds")
                     ltpSink.tryEmitNext(new LtpEvent(instrumentKey, ltp, Instant.ofEpochMilli(ts)));
                     writeTickToInflux(instrumentKey, tick.path("feeds").path(instrumentKey), ts);
                     lastLtp.put(instrumentKey, new LatestQuote(ltp, Instant.ofEpochMilli(ts)));
-                    nseInstrumentService.filterStrikesAroundLtp(ltp);
                 }
 
                 sink.tryEmitNext(tick);

--- a/src/test/java/com/trader/backend/service/NseInstrumentServiceTest.java
+++ b/src/test/java/com/trader/backend/service/NseInstrumentServiceTest.java
@@ -1,0 +1,48 @@
+package com.trader.backend.service;
+
+import com.trader.backend.entity.NseInstrument;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NseInstrumentServiceTest {
+    private NseInstrumentService svc = new NseInstrumentService(null, null, null, null, new ObjectMapper(), null);
+
+    @Test
+    void picksEarliestNonExpired() {
+        ZoneId ist = ZoneId.of("Asia/Kolkata");
+        LocalDate today = LocalDate.now(ist);
+        NseInstrument expired = inst("k1", today.minusMonths(1));
+        NseInstrument current = inst("k2", today.plusDays(5));
+        NseInstrument next = inst("k3", today.plusMonths(1));
+        Optional<NseInstrument> opt = svc.selectCurrentNiftyFuture(List.of(expired, current, next));
+        assertTrue(opt.isPresent());
+        assertEquals("k2", opt.get().getInstrument_key());
+    }
+
+    @Test
+    void skipsExpiredMonth() {
+        ZoneId ist = ZoneId.of("Asia/Kolkata");
+        LocalDate today = LocalDate.now(ist);
+        NseInstrument expired = inst("k1", today.minusDays(1));
+        NseInstrument next = inst("k2", today.plusMonths(1));
+        NseInstrument further = inst("k3", today.plusMonths(2));
+        Optional<NseInstrument> opt = svc.selectCurrentNiftyFuture(List.of(expired, next, further));
+        assertTrue(opt.isPresent());
+        assertEquals("k2", opt.get().getInstrument_key());
+    }
+
+    private static NseInstrument inst(String key, LocalDate date) {
+        NseInstrument i = new NseInstrument();
+        i.setInstrument_key(key);
+        long exp = date.atStartOfDay(ZoneId.of("Asia/Kolkata")).toInstant().toEpochMilli();
+        i.setExpiry(exp);
+        return i;
+    }
+}


### PR DESCRIPTION
## Summary
- Prevent duplicate key crashes by upserting the current NIFTY future document
- Ensure strike filtering runs only once and remove per-tick refresh triggers
- Add `/md/ltp` endpoint to serve the latest NIFTY future price with InfluxDB fallback
- Add unit tests to confirm expired futures are skipped

## Testing
- `mvn -q clean package -DskipTests -DskipFrontend=true` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af02cb691c832fa6f3adb95e36506a