### PR TITLE
Add resilient LTP endpoint with Influx fallback

### DIFF
--- a/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -45,6 +45,8 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
+import org.bson.Document;
+import com.mongodb.client.model.ReplaceOptions;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -606,8 +608,11 @@ public Optional<String> nearestNiftyFutureKey() {
         return Optional.empty();
     }
 
-    // persist chosen contract using upsert
-    mongoTemplate.save(current, "current_nifty_future");
+    // persist chosen contract using upsert to avoid duplicate key errors
+    Document doc = new Document();
+    mongoTemplate.getConverter().write(current, doc);
+    mongoTemplate.getCollection("current_nifty_future")
+            .replaceOne(new Document("_id", doc.get("_id")), doc, new ReplaceOptions().upsert(true));
 
     String chosenMonth = extractMonth(current.getTrading_symbol());
     List<String> reasons = new ArrayList<>();


### PR DESCRIPTION
## Summary
- Replace `/md/ltp` to accept `instrumentKey` and avoid 5xx by falling back to InfluxDB or returning 204
- Generalize `InfluxTickService` to fetch latest tick for futures or options
- Upsert selected NIFTY future into Mongo to stop duplicate key errors

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af24178670832fb71fa78763a1aeed