### PR TITLE
Add trade history endpoint with live fallback and Influx query

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -34,7 +34,8 @@ public class CorsConfig {
                 "/md/candles",
                 "/md/stream",
                 "/md/last-ltp",
-                "/md/ltp"
+                "/md/ltp",
+                "/md/trade-history"
         );
         paths.forEach(p -> source.registerCorsConfiguration(p, config));
 

--- a/src/main/java/com/trader/backend/dto/OptionType.java
+++ b/src/main/java/com/trader/backend/dto/OptionType.java
@@ -1,0 +1,5 @@
+package com.trader.backend.dto;
+
+public enum OptionType {
+    CE, PE
+}

--- a/src/main/java/com/trader/backend/dto/TradeRow.java
+++ b/src/main/java/com/trader/backend/dto/TradeRow.java
@@ -1,0 +1,15 @@
+package com.trader.backend.dto;
+
+import java.time.Instant;
+
+public record TradeRow(
+        Instant ts,
+        String instrumentKey,
+        OptionType optionType,
+        int strike,
+        double ltp,
+        double changePct,
+        int qty,
+        int oi,
+        String txId
+) {}

--- a/src/main/java/com/trader/backend/service/TradeHistoryService.java
+++ b/src/main/java/com/trader/backend/service/TradeHistoryService.java
@@ -1,0 +1,175 @@
+package com.trader.backend.service;
+
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.QueryApi;
+import com.influxdb.query.FluxRecord;
+import com.influxdb.query.FluxTable;
+import com.trader.backend.dto.OptionType;
+import com.trader.backend.dto.TradeRow;
+import com.trader.backend.entity.NseInstrument;
+import com.trader.backend.repository.NseInstrumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class TradeHistoryService {
+    private final LiveFeedService liveFeedService;
+    private final NseInstrumentService nseInstrumentService;
+    private final InfluxDBClient influxDBClient;
+    private final NseInstrumentRepository repo;
+
+    @Value("${influx.bucket:}")
+    private String influxBucket;
+    @Value("${influx.org:}")
+    private String influxOrg;
+
+    public record Result(List<TradeRow> rows, String source) {}
+
+    public Optional<Result> fetch(int limit, String side) {
+        NseInstrumentService.SelectionData sel = nseInstrumentService.currentSelectionData();
+        List<String> keys = sel.keys();
+        if (keys == null || keys.isEmpty()) {
+            return Optional.empty();
+        }
+        List<NseInstrument> instruments = new ArrayList<>();
+        for (String key : keys) {
+            repo.findById(key).ifPresent(instruments::add);
+        }
+        List<NseInstrument> options = instruments.stream()
+                .filter(i -> {
+                    String t = i.getInstrumentType();
+                    return t != null && (t.equalsIgnoreCase("CE") || t.equalsIgnoreCase("PE"));
+                })
+                .toList();
+        if (options.isEmpty()) {
+            return Optional.empty();
+        }
+        String sideUp = side.toUpperCase();
+        List<NseInstrument> filtered = options.stream()
+                .filter(i -> {
+                    String t = i.getInstrumentType();
+                    if ("CE".equals(sideUp)) return "CE".equalsIgnoreCase(t);
+                    if ("PE".equals(sideUp)) return "PE".equalsIgnoreCase(t);
+                    return true;
+                })
+                .toList();
+        if (filtered.isEmpty()) {
+            return Optional.of(new Result(List.of(), "live"));
+        }
+        List<String> symbols = filtered.stream()
+                .map(NseInstrument::getTrading_symbol)
+                .filter(Objects::nonNull)
+                .toList();
+
+        List<TradeRow> rows = fetchFromLive(symbols, limit);
+        String src = "live";
+        if (rows.isEmpty()) {
+            rows = fetchFromInflux(symbols, limit);
+            src = "influx";
+        }
+        return Optional.of(new Result(rows, src));
+    }
+
+    private List<TradeRow> fetchFromLive(List<String> symbols, int limit) {
+        List<TradeRow> out = new ArrayList<>();
+        for (String symbol : symbols) {
+            List<LiveFeedService.OptTick> ticks = liveFeedService.recentOptionTicks(symbol);
+            if (ticks.isEmpty()) continue;
+            for (int i = 0; i < ticks.size(); i++) {
+                LiveFeedService.OptTick t = ticks.get(i);
+                LiveFeedService.OptTick prev = (i + 1 < ticks.size()) ? ticks.get(i + 1) : null;
+                double changePct = (prev != null && prev.ltp() != 0)
+                        ? ((t.ltp() - prev.ltp()) / prev.ltp()) * 100.0 : 0.0;
+                OptionType type = symbol.endsWith("PE") ? OptionType.PE : OptionType.CE;
+                int strike = parseStrike(symbol);
+                String txId = t.instrumentKey() + "-" + t.ts().getEpochSecond();
+                out.add(new TradeRow(t.ts(), t.instrumentKey(), type, strike, t.ltp(), changePct, t.qty(), t.oi(), txId));
+            }
+        }
+        out.sort(Comparator.comparing(TradeRow::ts).reversed());
+        if (out.size() > limit) {
+            return new ArrayList<>(out.subList(0, limit));
+        }
+        return out;
+    }
+
+    private List<TradeRow> fetchFromInflux(List<String> symbols, int limit) {
+        if (symbols.isEmpty()) return List.of();
+        String set = String.join(",", symbols.stream().map(s -> "\"" + s + "\"").toList());
+        String flux = String.format("from(bucket: \"%s\") |> range(start: -1d) |> " +
+                        "filter(fn: (r) => r._measurement == \"nifty_option_ticks\") |> " +
+                        "filter(fn: (r) => contains(value: r.symbol, set: [%s])) |> " +
+                        "filter(fn: (r) => r._field == \"ltp\" or r._field == \"qty\" or r._field == \"oi\") |> " +
+                        "pivot(rowKey:[\"_time\",\"symbol\",\"instrumentKey\"], columnKey:[\"_field\"], valueColumn:\"_value\") |> " +
+                        "sort(columns:[\"_time\"], desc:true) |> limit(n:%d)",
+                influxBucket, set, limit * 3);
+
+        QueryApi queryApi = influxDBClient.getQueryApi();
+        List<FluxTable> tables = queryApi.query(flux, influxOrg);
+        Map<String, List<FluxRecord>> bySymbol = new HashMap<>();
+        for (FluxTable table : tables) {
+            for (FluxRecord rec : table.getRecords()) {
+                String symbol = (String) rec.getValueByKey("symbol");
+                bySymbol.computeIfAbsent(symbol, k -> new ArrayList<>()).add(rec);
+            }
+        }
+        List<TradeRow> out = new ArrayList<>();
+        for (var entry : bySymbol.entrySet()) {
+            List<FluxRecord> recs = entry.getValue();
+            for (int i = 0; i < recs.size(); i++) {
+                FluxRecord rec = recs.get(i);
+                FluxRecord prev = (i + 1 < recs.size()) ? recs.get(i + 1) : null;
+                Double ltp = getDouble(rec, "ltp");
+                if (ltp == null) continue;
+                Double prevLtp = prev != null ? getDouble(prev, "ltp") : null;
+                double changePct = (prevLtp != null && prevLtp != 0.0) ? ((ltp - prevLtp) / prevLtp) * 100.0 : 0.0;
+                int qty = getDouble(rec, "qty") != null ? getDouble(rec, "qty").intValue() : 0;
+                int oi = getDouble(rec, "oi") != null ? getDouble(rec, "oi").intValue() : 0;
+                String instrumentKey = (String) rec.getValueByKey("instrumentKey");
+                Instant ts = (Instant) rec.getValueByKey("_time");
+                String symbol = entry.getKey();
+                OptionType type = symbol.endsWith("PE") ? OptionType.PE : OptionType.CE;
+                int strike = parseStrike(symbol);
+                String txId = instrumentKey + "-" + ts.getEpochSecond();
+                out.add(new TradeRow(ts, instrumentKey, type, strike, ltp, changePct, qty, oi, txId));
+            }
+        }
+        out.sort(Comparator.comparing(TradeRow::ts).reversed());
+        if (out.size() > limit) {
+            return new ArrayList<>(out.subList(0, limit));
+        }
+        return out;
+    }
+
+    private Double getDouble(FluxRecord rec, String field) {
+        Object v = rec.getValueByKey(field);
+        return v instanceof Number n ? n.doubleValue() : null;
+    }
+
+    private int parseStrike(String symbol) {
+        int i = symbol.length() - 1;
+        while (i >= 0 && !Character.isDigit(symbol.charAt(i))) {
+            i--;
+        }
+        int end = i + 1;
+        while (i >= 0 && Character.isDigit(symbol.charAt(i))) {
+            i--;
+        }
+        try {
+            return Integer.parseInt(symbol.substring(i + 1, end));
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add OptionType and TradeRow DTOs
- record option ticks in memory and expose trade history endpoint
- include trade history path in CORS config

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM: Network is unreachable)*

## Task Summary
- Added GET /md/trade-history with params {limit, side}.
- Provides CE/PE option trades merged and sorted by time; uses live ring buffers when available, otherwise falls back to Influx with a Flux query.
- Response shape TradeRow is stable and documented.
- No extra noisy logs; CORS updated.

## Handoff to Frontend
- Base: <existing apiBase>
- Endpoint: GET /md/trade-history?limit=50&side=both
- Response: Array<TradeRow>
  {
    ts: string (ISO UTC),
    instrumentKey: string,
    optionType: "CE"|"PE",
    strike: number,
    ltp: number,
    changePct: number,
    qty: number,
    oi: number,
    txId: string
  }
- Semantics:
  • Sorted by ts DESC, merged across CE/PE.
  • changePct is vs previous tick of the same symbol.
  • When market is closed, data is served from Influx (last 1d).
  • 204 means "no instruments configured"; 200 [] means "no rows".


------
https://chatgpt.com/codex/tasks/task_e_68af57772e9c832f81cf3990e05f3055