### PR TITLE
Add sector trades endpoint

### DIFF
--- a/src/main/java/com/trader/backend/controller/MdController.java
+++ b/src/main/java/com/trader/backend/controller/MdController.java
@@ -190,12 +190,10 @@ public class MdController {
         if (!Set.of("CE", "PE", "BOTH").contains(s)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "side");
         }
-        Optional<TradeHistoryService.Result> resOpt = tradeHistoryService.fetch(lim, s);
-        if (resOpt.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
-        TradeHistoryService.Result res = resOpt.get();
-        log.info("GET /md/sector-trades?limit={}&side={} — src={} — rows={}", lim, s, res.source(), res.rows().size());
-        return ResponseEntity.ok(res.rows());
+        Optional<TradeHistoryService.Result> resOpt = tradeHistoryService.fetchRecentOptionTrades(lim, s);
+        List<TradeRow> rows = resOpt.map(TradeHistoryService.Result::rows).orElse(List.of());
+        String src = resOpt.map(TradeHistoryService.Result::source).orElse("none");
+        log.info("GET /md/sector-trades side={} limit={} src={} count={}", s, lim, src, rows.size());
+        return ResponseEntity.ok(rows);
     }
 }

--- a/src/main/java/com/trader/backend/dto/TradeRow.java
+++ b/src/main/java/com/trader/backend/dto/TradeRow.java
@@ -10,6 +10,6 @@ public record TradeRow(
         double ltp,
         double changePct,
         int qty,
-        int oi,
+        Integer oi,
         String txId
 ) {}

--- a/src/test/java/com/trader/backend/controller/MdControllerTest.java
+++ b/src/test/java/com/trader/backend/controller/MdControllerTest.java
@@ -1,0 +1,70 @@
+package com.trader.backend.controller;
+
+import com.trader.backend.dto.OptionType;
+import com.trader.backend.dto.TradeRow;
+import com.trader.backend.service.CandleService;
+import com.trader.backend.service.InfluxTickService;
+import com.trader.backend.service.LiveFeedService;
+import com.trader.backend.service.NseInstrumentService;
+import com.trader.backend.service.SelectionService;
+import com.trader.backend.service.TradeHistoryService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+@WebFluxTest(MdController.class)
+class MdControllerTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockBean private CandleService candleService;
+    @MockBean private LiveFeedService liveFeedService;
+    @MockBean private NseInstrumentService nseInstrumentService;
+    @MockBean private SelectionService selectionService;
+    @MockBean private InfluxTickService influxTickService;
+    @MockBean private TradeHistoryService tradeHistoryService;
+
+    @Test
+    void sectorTradesReturnsArray() {
+        TradeRow row = new TradeRow(
+                Instant.parse("2025-08-27T10:21:30Z"),
+                "NSE_FO|64103",
+                OptionType.CE,
+                24800,
+                182.5,
+                -0.12,
+                5,
+                120000,
+                "NSE_FO|64103-1693125690");
+        Mockito.when(tradeHistoryService.fetchRecentOptionTrades(50, "both"))
+                .thenReturn(Optional.of(new TradeHistoryService.Result(List.of(row), "live")));
+
+        webTestClient.get().uri("/md/sector-trades")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TradeRow.class)
+                .hasSize(1)
+                .contains(row);
+    }
+
+    @Test
+    void sectorTradesNoDataReturnsEmptyArray() {
+        Mockito.when(tradeHistoryService.fetchRecentOptionTrades(50, "both"))
+                .thenReturn(Optional.empty());
+
+        webTestClient.get().uri("/md/sector-trades")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(TradeRow.class)
+                .hasSize(0);
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose `/md/sector-trades` with limit/side filters and concise logging
- provide live and InfluxDB option trade history with pct change, qty fallback and optional OI
- cover controller contract with WebFlux tests

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to jitpack.io (Network is unreachable))*

------
https://chatgpt.com/codex/tasks/task_e_68af66c2279c832fb1c0ae86c24c1d7e