### PR TITLE
Align future tick measurement with InfluxDB conventions

### DIFF
--- a/src/main/java/com/trader/backend/service/CandleService.java
+++ b/src/main/java/com/trader/backend/service/CandleService.java
@@ -57,7 +57,7 @@ public class CandleService {
             return null;
         }
         String measurement = "FUT".equalsIgnoreCase(opt.get().getInstrumentType()) ?
-                "nifty_fut_ticks" : "nifty_option_ticks";
+                "nifty_future_ticks" : "nifty_option_ticks";
         String flux = String.format("from(bucket: \"%s\") |> range(start: -1d) |> " +
                         "filter(fn: (r) => r._measurement == \"%s\" and r.instrumentKey == \"%s\" and r._field == \"ltp\") |> last()",
                 influxBucket, measurement, instrumentKey);
@@ -80,7 +80,7 @@ public class CandleService {
             return new CandleResponse(key, tf, List.of());
         }
         String measurement = "FUT".equalsIgnoreCase(opt.get().getInstrumentType()) ?
-                "nifty_fut_ticks" : "nifty_option_ticks";
+                "nifty_future_ticks" : "nifty_option_ticks";
 
         Map<Instant, CandleBuilder> map = new HashMap<>();
 

--- a/src/main/java/com/trader/backend/service/InfluxTickService.java
+++ b/src/main/java/com/trader/backend/service/InfluxTickService.java
@@ -38,7 +38,7 @@ public class InfluxTickService {
             return Optional.empty();
         }
         String measurement = "FUT".equalsIgnoreCase(opt.get().getInstrumentType()) ?
-                "nifty_fut_ticks" : "nifty_option_ticks";
+                "nifty_future_ticks" : "nifty_option_ticks";
         String flux = String.format("from(bucket: \"%s\") |> range(start: -30d) |> " +
                         "filter(fn: (r) => r._measurement == \"%s\" and r.instrumentKey == \"%s\" and r._field == \"ltp\") |> last()",
                 influxBucket, measurement, instrumentKey);

--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -736,7 +736,7 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
                 k -> mongoTemplate.findById(k, NseInstrument.class));
         if (info == null) return;
         boolean isFut = info.getInstrumentType() != null && info.getInstrumentType().toUpperCase().contains("FUT");
-        String measurement = isFut ? "nifty_fut_ticks" : "nifty_option_ticks";
+        String measurement = isFut ? "nifty_future_ticks" : "nifty_option_ticks";
 
         long exp = info.getExpiry();
         if (exp < 1_000_000_000_000L) exp *= 1000L;


### PR DESCRIPTION
## Summary
- use `nifty_future_ticks` as the unified measurement name for future ticks
- update services reading/writing Influx to the new measurement

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0000e7214832fbfe214a3a2f9d1d4