### PR TITLE
Clarify LTP source and add periodic summaries

### DIFF
--- a/src/main/java/com/trader/backend/service/LtpService.java
+++ b/src/main/java/com/trader/backend/service/LtpService.java
@@ -1,0 +1,33 @@
+package com.trader.backend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LtpService {
+    private final LiveFeedService liveFeedService;
+    private final InfluxTickService influxTickService;
+
+    public record Result(Double ltp, Instant ts, String source) {}
+
+    public Result resolve(String instrumentKey) {
+        Instant now = Instant.now();
+        Optional<Tick> live = liveFeedService.getLatestTick(instrumentKey)
+                .filter(t -> Duration.between(t.ts(), now).toMillis() <= 5000);
+        if (live.isPresent()) {
+            Tick t = live.get();
+            return new Result(t.ltp(), t.ts(), "live");
+        }
+        Optional<Tick> stored = influxTickService.latestTick(instrumentKey);
+        if (stored.isPresent()) {
+            Tick t = stored.get();
+            return new Result(t.ltp(), t.ts(), "stored");
+        }
+        return new Result(null, null, "none");
+    }
+}


### PR DESCRIPTION
## Summary
- extend `/md/ltp` to report data source and age, with single-line logging
- resolve LTP using new service that prefers live ticks and falls back to stored
- log 5s LTP summaries and 60s Influx write rollups

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from jitpack.io: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b0073b3600832f8571930c34b0357f