### PR TITLE
Expose live feed status endpoints and refine Influx tick handling

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -35,7 +35,10 @@ public class CorsConfig {
                 "/md/stream",
                 "/md/last-ltp",
                 "/md/ltp",
-                "/md/sector-trades"
+                "/md/sector-trades",
+                "/ops/live-status",
+                "/ops/influx-sanity",
+                "/ops/market-clock"
         );
         paths.forEach(p -> source.registerCorsConfiguration(p, config));
 

--- a/src/main/java/com/trader/backend/controller/OpsController.java
+++ b/src/main/java/com/trader/backend/controller/OpsController.java
@@ -1,6 +1,8 @@
 package com.trader.backend.controller;
 
 import com.trader.backend.service.MarketHours;
+import com.trader.backend.service.LiveFeedService;
+import com.trader.backend.service.InfluxTickService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,6 +12,13 @@ import java.util.Map;
 
 @RestController
 public class OpsController {
+    private final LiveFeedService liveFeedService;
+    private final InfluxTickService influxTickService;
+
+    public OpsController(LiveFeedService liveFeedService, InfluxTickService influxTickService) {
+        this.liveFeedService = liveFeedService;
+        this.influxTickService = influxTickService;
+    }
 
     @GetMapping("/ops/market-clock")
     public Map<String, Object> marketClock() {
@@ -37,6 +46,29 @@ public class OpsController {
         m.put("nextAutoStartAtUtc", nextAutoStart != null ? nextAutoStart.toString() : null);
         m.put("serverZoneId", ZoneId.systemDefault().getId());
         m.put("serverInstant", Instant.now().toString());
+        return m;
+    }
+
+    @GetMapping("/ops/live-status")
+    public Map<String, Object> liveStatus() {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("connected", liveFeedService.isConnected());
+        Instant ts = liveFeedService.lastTickTs();
+        m.put("lastTickTs", ts != null ? ts.toString() : null);
+        m.put("ticksLast60s", liveFeedService.ticksLast60s());
+        m.put("futSubscribed", liveFeedService.futSubscribed());
+        m.put("optSubscribedCount", liveFeedService.optSubscribedCount());
+        return m;
+    }
+
+    @GetMapping("/ops/influx-sanity")
+    public Map<String, Object> influxSanity() {
+        InfluxTickService.Sanity s = influxTickService.sanityLast2m();
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("futPoints", s.futPoints());
+        m.put("optPoints", s.optPoints());
+        m.put("futLastTs", s.futLastTs() != null ? s.futLastTs().toString() : null);
+        m.put("optLastTs", s.optLastTs() != null ? s.optLastTs().toString() : null);
         return m;
     }
 }


### PR DESCRIPTION
## Summary
- track WebSocket connection state and last tick timestamp
- expose new /ops/live-status and /ops/influx-sanity endpoints
- streamline Influx tick writer with proper tags and periodic summaries

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b0129a0754832fa8e9663c1a6957e5