### PR TITLE
fix: align NseInstrument getters with camelCase

### DIFF
--- a/src/main/java/com/trader/backend/entity/NseInstrument.java
+++ b/src/main/java/com/trader/backend/entity/NseInstrument.java
@@ -1,222 +1,11 @@
 package com.trader.backend.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
-
-/*
-
-@Data
-@Document(collection = "nse_instruments")
-public class NseInstrument {
-
-    @Id
-    private String instrument_key;
-
-    private boolean weekly;
-    private String segment;
-    private String name;
-    private String exchange;
-    private long expiry;
-    */
-/*@Field("instrument_type")
-    private String instrumentType;
-*//*
-
-    @Field("instrument_type")
-    private String instrumentType;
-
-    public String getInstrument_key() {
-        return instrument_key;
-    }
-
-    public void setInstrument_key(String instrument_key) {
-        this.instrument_key = instrument_key;
-    }
-
-    public boolean isWeekly() {
-        return weekly;
-    }
-
-    public void setWeekly(boolean weekly) {
-        this.weekly = weekly;
-    }
-
-    public String getSegment() {
-        return segment;
-    }
-
-    public void setSegment(String segment) {
-        this.segment = segment;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getExchange() {
-        return exchange;
-    }
-
-    public void setExchange(String exchange) {
-        this.exchange = exchange;
-    }
-
-    public long getExpiry() {
-        return expiry;
-    }
-
-    public void setExpiry(long expiry) {
-        this.expiry = expiry;
-    }
-
-    public String getInstrumentType() {
-        return instrumentType;
-    }
-
-    public void setInstrumentType(String instrumentType) {
-        this.instrumentType = instrumentType;
-    }
-
-    public double getStrikePrice() {
-        return strikePrice;
-    }
-
-    public void setStrikePrice(double strikePrice) {
-        this.strikePrice = strikePrice;
-    }
-
-    public String getAsset_symbol() {
-        return asset_symbol;
-    }
-
-    public void setAsset_symbol(String asset_symbol) {
-        this.asset_symbol = asset_symbol;
-    }
-
-    public String getUnderlying_symbol() {
-        return underlying_symbol;
-    }
-
-    public void setUnderlying_symbol(String underlying_symbol) {
-        this.underlying_symbol = underlying_symbol;
-    }
-
-    public int getLot_size() {
-        return lot_size;
-    }
-
-    public void setLot_size(int lot_size) {
-        this.lot_size = lot_size;
-    }
-
-    public double getFreeze_quantity() {
-        return freeze_quantity;
-    }
-
-    public void setFreeze_quantity(double freeze_quantity) {
-        this.freeze_quantity = freeze_quantity;
-    }
-
-    public String getExchange_token() {
-        return exchange_token;
-    }
-
-    public void setExchange_token(String exchange_token) {
-        this.exchange_token = exchange_token;
-    }
-
-    public int getMinimum_lot() {
-        return minimum_lot;
-    }
-
-    public void setMinimum_lot(int minimum_lot) {
-        this.minimum_lot = minimum_lot;
-    }
-
-    public String getAsset_key() {
-        return asset_key;
-    }
-
-    public void setAsset_key(String asset_key) {
-        this.asset_key = asset_key;
-    }
-
-    public String getUnderlying_key() {
-        return underlying_key;
-    }
-
-    public void setUnderlying_key(String underlying_key) {
-        this.underlying_key = underlying_key;
-    }
-
-    public double getTick_size() {
-        return tick_size;
-    }
-
-    public void setTick_size(double tick_size) {
-        this.tick_size = tick_size;
-    }
-
-    public String getAsset_type() {
-        return asset_type;
-    }
-
-    public void setAsset_type(String asset_type) {
-        this.asset_type = asset_type;
-    }
-
-    public String getUnderlying_type() {
-        return underlying_type;
-    }
-
-    public void setUnderlying_type(String underlying_type) {
-        this.underlying_type = underlying_type;
-    }
-
-    public String getTrading_symbol() {
-        return trading_symbol;
-    }
-
-    public void setTrading_symbol(String trading_symbol) {
-        this.trading_symbol = trading_symbol;
-    }
-
-    public double getQty_multiplier() {
-        return qty_multiplier;
-    }
-
-    public void setQty_multiplier(double qty_multiplier) {
-        this.qty_multiplier = qty_multiplier;
-    }
-
-    @Field("strike_price")
-    private double strikePrice;
-
-    private String asset_symbol;
-    private String underlying_symbol;
-    private int lot_size;
-    private double freeze_quantity;
-    private String exchange_token;
-    private int minimum_lot;
-    private String asset_key;
-    private String underlying_key;
-    private double tick_size;
-    private String asset_type;
-    private String underlying_type;
-    private String trading_symbol;
-   // private double strike_price;
-    private double qty_multiplier;
-}
-*/
-
-
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
@@ -225,65 +14,87 @@ public class NseInstrument {
 
     @Id
     @JsonProperty("instrument_key")
-    private String instrument_key;
+    @Field("instrument_key")
+    private String instrumentKey;
 
     @JsonProperty("weekly")
+    @Field("weekly")
     private boolean weekly;
 
     @JsonProperty("segment")
+    @Field("segment")
     private String segment;
 
     @JsonProperty("name")
+    @Field("name")
     private String name;
 
     @JsonProperty("exchange")
+    @Field("exchange")
     private String exchange;
 
     @JsonProperty("expiry")
+    @Field("expiry")
     private long expiry;
 
     @JsonProperty("instrument_type")
+    @Field("instrument_type")
     private String instrumentType;
 
     @JsonProperty("strike_price")
-    private double strikePrice;
+    @Field("strike_price")
+    private Integer strikePrice;
 
     @JsonProperty("asset_symbol")
-    private String asset_symbol;
+    @Field("asset_symbol")
+    private String assetSymbol;
 
     @JsonProperty("underlying_symbol")
-    private String underlying_symbol;
+    @Field("underlying_symbol")
+    private String underlyingSymbol;
 
     @JsonProperty("lot_size")
-    private int lot_size;
+    @Field("lot_size")
+    private int lotSize;
 
     @JsonProperty("freeze_quantity")
-    private double freeze_quantity;
+    @Field("freeze_quantity")
+    private double freezeQuantity;
 
     @JsonProperty("exchange_token")
-    private String exchange_token;
+    @Field("exchange_token")
+    private String exchangeToken;
 
     @JsonProperty("minimum_lot")
-    private int minimum_lot;
+    @Field("minimum_lot")
+    private int minimumLot;
 
     @JsonProperty("asset_key")
-    private String asset_key;
+    @Field("asset_key")
+    private String assetKey;
 
     @JsonProperty("underlying_key")
-    private String underlying_key;
+    @Field("underlying_key")
+    private String underlyingKey;
 
     @JsonProperty("tick_size")
-    private double tick_size;
+    @Field("tick_size")
+    private double tickSize;
 
     @JsonProperty("asset_type")
-    private String asset_type;
+    @Field("asset_type")
+    private String assetType;
 
     @JsonProperty("underlying_type")
-    private String underlying_type;
+    @Field("underlying_type")
+    private String underlyingType;
 
     @JsonProperty("trading_symbol")
-    private String trading_symbol;
+    @Field("trading_symbol")
+    private String tradingSymbol;
 
     @JsonProperty("qty_multiplier")
-    private double qty_multiplier;
+    @Field("qty_multiplier")
+    private double qtyMultiplier;
 }
+

--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -818,7 +818,9 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
         String t = info.getInstrumentType();
         if (!isFut && t != null) {
             p.addTag("type", t.toUpperCase());
-            p.addTag("strike", String.valueOf(info.getStrike_price())) ;
+            Integer sp = info.getStrikePrice();
+            int strike = (sp != null) ? sp : 0;
+            p.addTag("strike", String.valueOf(strike));
         }
 
         JsonNode ltpNode = findField(feed, "ltp");
@@ -847,7 +849,7 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
         if (info == null) return;
         String type = info.getInstrumentType();
         if (type == null || !(type.equalsIgnoreCase("CE") || type.equalsIgnoreCase("PE"))) return;
-        String symbol = info.getTrading_symbol();
+        String symbol = info.getTradingSymbol();
         if (symbol == null) return;
         int qty = findIntField(feed, "qty");
         int oi = findIntField(feed, "oi");

--- a/src/main/java/com/trader/backend/service/TradeHistoryService.java
+++ b/src/main/java/com/trader/backend/service/TradeHistoryService.java
@@ -68,7 +68,7 @@ public class TradeHistoryService {
             return Optional.of(new Result(List.of(), "live"));
         }
         List<String> symbols = filtered.stream()
-                .map(NseInstrument::getTrading_symbol)
+                .map(NseInstrument::getTradingSymbol)
                 .filter(Objects::nonNull)
                 .toList();
 


### PR DESCRIPTION
## Summary
- replace underscore-based getter calls with camelCase versions
- refactor `NseInstrument` to camelCase fields with `@JsonProperty`/`@Field` mappings
- handle null strike price and correct trading symbol access

## Testing
- `mvn package -DskipTests` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b016c77e28832f82cc576f0fe331ad