### PR TITLE
fix: update tests for camelCase NseInstrument getters

### DIFF
--- a/src/main/java/com/trader/backend/entity/NseInstrument.java
+++ b/src/main/java/com/trader/backend/entity/NseInstrument.java
@@ -1,5 +1,6 @@
 package com.trader.backend.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
@@ -96,5 +97,53 @@ public class NseInstrument {
     @JsonProperty("qty_multiplier")
     @Field("qty_multiplier")
     private double qtyMultiplier;
+
+    @Deprecated
+    @JsonIgnore
+    public String getInstrument_key() {
+        return getInstrumentKey();
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public void setInstrument_key(String v) {
+        setInstrumentKey(v);
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public String getAsset_symbol() {
+        return getAssetSymbol();
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public void setAsset_symbol(String v) {
+        setAssetSymbol(v);
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public String getUnderlying_symbol() {
+        return getUnderlyingSymbol();
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public void setUnderlying_symbol(String v) {
+        setUnderlyingSymbol(v);
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public String getExchange_token() {
+        return getExchangeToken();
+    }
+
+    @Deprecated
+    @JsonIgnore
+    public void setExchange_token(String v) {
+        setExchangeToken(v);
+    }
 }
 

--- a/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -283,8 +283,11 @@ public class UpstoxAuthService {
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
                 .map(resp -> {
+                    @SuppressWarnings("unchecked")
                     Map<String, Object> data = (Map<String, Object>) resp.get("data");
-                    return (Map<String, Object>) data.get(exchange + ":" + symbol);
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> quote = (Map<String, Object>) data.get(exchange + ":" + symbol);
+                    return quote;
                 });
     }
 

--- a/src/test/java/com/trader/backend/service/NseInstrumentServiceTest.java
+++ b/src/test/java/com/trader/backend/service/NseInstrumentServiceTest.java
@@ -23,7 +23,7 @@ public class NseInstrumentServiceTest {
         NseInstrument next = inst("k3", today.plusMonths(1));
         Optional<NseInstrument> opt = svc.selectCurrentNiftyFuture(List.of(expired, current, next));
         assertTrue(opt.isPresent());
-        assertEquals("k2", opt.get().getInstrument_key());
+        assertEquals("k2", opt.get().getInstrumentKey());
     }
 
     @Test
@@ -35,12 +35,12 @@ public class NseInstrumentServiceTest {
         NseInstrument further = inst("k3", today.plusMonths(2));
         Optional<NseInstrument> opt = svc.selectCurrentNiftyFuture(List.of(expired, next, further));
         assertTrue(opt.isPresent());
-        assertEquals("k2", opt.get().getInstrument_key());
+        assertEquals("k2", opt.get().getInstrumentKey());
     }
 
     private static NseInstrument inst(String key, LocalDate date) {
         NseInstrument i = new NseInstrument();
-        i.setInstrument_key(key);
+        i.setInstrumentKey(key);
         long exp = date.atStartOfDay(ZoneId.of("Asia/Kolkata")).toInstant().toEpochMilli();
         i.setExpiry(exp);
         return i;


### PR DESCRIPTION
## Summary
- update tests to use camelCase NseInstrument accessors
- add deprecated snake_case bridge methods on NseInstrument
- suppress unchecked cast in UpstoxAuthService

## Testing
- `./mvnw -q -DskipFrontend=true -DskipTests=false test` *(fails: Non-resolvable parent POM for com.trader:backend)*
- `./mvnw -q -DskipFrontend=true package` *(fails: Non-resolvable parent POM for com.trader:backend)*

------
https://chatgpt.com/codex/tasks/task_e_68b01ab9bdbc832fb599cb221e618931