### PR TITLE
feat: refresh weekly options and log ltp source

### DIFF
--- a/src/main/java/com/trader/backend/service/LtpService.java
+++ b/src/main/java/com/trader/backend/service/LtpService.java
@@ -21,11 +21,13 @@ public class LtpService {
                 .filter(t -> Duration.between(t.ts(), now).toMillis() <= 5000);
         if (live.isPresent()) {
             Tick t = live.get();
+            liveFeedService.logResolvedLtp(instrumentKey, t.ltp(), "live");
             return new Result(t.ltp(), t.ts(), "live");
         }
         Optional<Tick> stored = influxTickService.latestTick(instrumentKey);
         if (stored.isPresent()) {
             Tick t = stored.get();
+            liveFeedService.logResolvedLtp(instrumentKey, t.ltp(), "stored");
             return new Result(t.ltp(), t.ts(), "influx");
         }
         return new Result(null, null, "none");

--- a/src/test/java/com/trader/backend/service/NseInstrumentServiceTest.java
+++ b/src/test/java/com/trader/backend/service/NseInstrumentServiceTest.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class NseInstrumentServiceTest {
-    private NseInstrumentService svc = new NseInstrumentService(null, null, null, null, new ObjectMapper(), null);
+    private NseInstrumentService svc = new NseInstrumentService(null, null, null, null, new ObjectMapper(), null, null, null);
 
     @Test
     void picksEarliestNonExpired() {


### PR DESCRIPTION
## Summary
- schedule daily NSE option universe refresh and weekly rollover using ExpirySelectorService
- log LTP source for futures and options, distinguishing live ticks from stored fallback
- guard option streaming on presence of instruments in DB

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b12c411654832f9e4585e97beac40f