### PR TITLE
feat: auto refresh options when empty

### DIFF
--- a/src/main/java/com/trader/backend/service/ExpirySelectorService.java
+++ b/src/main/java/com/trader/backend/service/ExpirySelectorService.java
@@ -35,6 +35,11 @@ public class ExpirySelectorService {
         return currentExpiry;
     }
 
+    /** Public entry for option expiry selection with explicit IST instant. */
+    public LocalDate selectCurrentOptionExpiry(Instant now) {
+        return pickCurrentExpiry(now);
+    }
+
     private LocalDate computeExpiry(ZonedDateTime z) {
         DayOfWeek dow = z.getDayOfWeek();
         LocalDate date = z.toLocalDate();

--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -146,7 +146,10 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
     public void subscribeToAuthEvents() {
         auth.events()
                 .filter(e -> e == UpstoxAuthService.AuthEvent.READY)
-                .subscribe(ev -> connectIfOpenOrSchedule());
+                .subscribe(ev -> {
+                    nseInstrumentService.refreshIfOptionsEmpty();
+                    connectIfOpenOrSchedule();
+                });
 
         auth.events()
                 .filter(e -> e == UpstoxAuthService.AuthEvent.EXPIRED)
@@ -229,7 +232,7 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
             if (instrumentsInitialized.compareAndSet(false, true)) {
                 nseInstrumentService.ensureNseJsonLoaded();
                 nseInstrumentService.purgeExpiredOptionDocs();
-                nseInstrumentService.refreshNiftyOptionsByNearestExpiryFromJson();
+                nseInstrumentService.refreshIfOptionsEmpty();
                 nseInstrumentService.saveNiftyFuturesToMongo();
             } else {
                 log.info("init sequence skipped: already initialized");


### PR DESCRIPTION
## Summary
- add refreshFromNseJson and refreshIfOptionsEmpty to reload option instruments and set current expiry
- trigger option refresh after auth, during live feed init, and sector-trades endpoint; add admin refresh endpoint

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b12f52357c832fa83a3eb149e3ca0a