### PR TITLE
feat: auto-load option instruments

### DIFF
--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -214,6 +214,15 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
         initLiveWebSocket();
     }
 
+    /**
+     * Public entry to start or resume feeds ensuring option instruments exist.
+     */
+    public void startOrResume() {
+        ZonedDateTime nowIst = ZonedDateTime.now(MarketHours.zone());
+        nseInstrumentService.ensureOptionsLoaded(nowIst);
+        startLive();
+    }
+
     public void initLiveWebSocket() {
         if (mockMode) {
             log.info("🧪 Mock mode enabled - skipping live feed startup");

--- a/src/test/java/com/trader/backend/service/ExpirySelectorServiceTest.java
+++ b/src/test/java/com/trader/backend/service/ExpirySelectorServiceTest.java
@@ -19,33 +19,33 @@ class ExpirySelectorServiceTest {
 
     @Test
     void mondayUsesThisThursday() {
-        Instant monday = LocalDate.of(2024, 1, 1).atTime(10, 0).atZone(IST).toInstant();
-        assertEquals(LocalDate.of(2024, 1, 4), service.pickCurrentExpiry(monday));
+        ZonedDateTime monday = LocalDate.of(2024, 1, 1).atTime(10, 0).atZone(IST);
+        assertEquals(LocalDate.of(2024, 1, 4), service.selectCurrentOptionExpiry(monday));
     }
 
     @Test
     void thursdayBeforeCloseUsesToday() {
-        Instant thursday = LocalDate.of(2024, 1, 4).atTime(10, 0).atZone(IST).toInstant();
-        assertEquals(LocalDate.of(2024, 1, 4), service.pickCurrentExpiry(thursday));
+        ZonedDateTime thursday = LocalDate.of(2024, 1, 4).atTime(10, 0).atZone(IST);
+        assertEquals(LocalDate.of(2024, 1, 4), service.selectCurrentOptionExpiry(thursday));
     }
 
     @Test
     void thursdayAfterCloseRollsOver() {
-        Instant thursday = LocalDate.of(2024, 1, 4).atTime(16, 0).atZone(IST).toInstant();
-        assertEquals(LocalDate.of(2024, 1, 11), service.pickCurrentExpiry(thursday));
+        ZonedDateTime thursday = LocalDate.of(2024, 1, 4).atTime(16, 0).atZone(IST);
+        assertEquals(LocalDate.of(2024, 1, 11), service.selectCurrentOptionExpiry(thursday));
     }
 
     @Test
     void fridayUsesNextThursday() {
-        Instant friday = LocalDate.of(2024, 1, 5).atTime(10, 0).atZone(IST).toInstant();
-        assertEquals(LocalDate.of(2024, 1, 11), service.pickCurrentExpiry(friday));
+        ZonedDateTime friday = LocalDate.of(2024, 1, 5).atTime(10, 0).atZone(IST);
+        assertEquals(LocalDate.of(2024, 1, 11), service.selectCurrentOptionExpiry(friday));
     }
 
     @Test
     void monthlyRolloverHandled() {
         // 25 April 2024 is the last Thursday of the month
-        Instant afterMonthly = LocalDate.of(2024, 4, 26).atTime(10, 0).atZone(IST).toInstant();
-        assertEquals(LocalDate.of(2024, 5, 2), service.pickCurrentExpiry(afterMonthly));
+        ZonedDateTime afterMonthly = LocalDate.of(2024, 4, 26).atTime(10, 0).atZone(IST);
+        assertEquals(LocalDate.of(2024, 5, 2), service.selectCurrentOptionExpiry(afterMonthly));
     }
 }
 


### PR DESCRIPTION
## Summary
- track and persist current NIFTY option expiry
- refresh options when empty and expose admin refresh endpoint
- add startOrResume hook for live feed with option pre-check

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b134122874832fac6486a37923dc88