### PR TITLE
Fix NseInstrument getters and setters

### DIFF
--- a/src/main/java/com/trader/backend/entity/NseInstrument.java
+++ b/src/main/java/com/trader/backend/entity/NseInstrument.java
@@ -2,13 +2,11 @@ package com.trader.backend.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@Data
 @Document(collection = "nse_instruments")
 public class NseInstrument {
 
@@ -96,5 +94,68 @@ public class NseInstrument {
     @JsonProperty("qty_multiplier")
     @Field("qty_multiplier")
     private double qtyMultiplier;
+
+    public String getInstrumentKey() { return instrumentKey; }
+    public void setInstrumentKey(String instrumentKey) { this.instrumentKey = instrumentKey; }
+
+    public boolean isWeekly() { return weekly; }
+    public void setWeekly(boolean weekly) { this.weekly = weekly; }
+
+    public String getSegment() { return segment; }
+    public void setSegment(String segment) { this.segment = segment; }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+
+    public String getExchange() { return exchange; }
+    public void setExchange(String exchange) { this.exchange = exchange; }
+
+    public long getExpiry() { return expiry; }
+    public void setExpiry(long expiry) { this.expiry = expiry; }
+
+    public String getInstrumentType() { return instrumentType; }
+    public void setInstrumentType(String instrumentType) { this.instrumentType = instrumentType; }
+
+    public Integer getStrikePrice() { return strikePrice; }
+    public void setStrikePrice(Integer strikePrice) { this.strikePrice = strikePrice; }
+
+    public String getAssetSymbol() { return assetSymbol; }
+    public void setAssetSymbol(String assetSymbol) { this.assetSymbol = assetSymbol; }
+
+    public String getUnderlyingSymbol() { return underlyingSymbol; }
+    public void setUnderlyingSymbol(String underlyingSymbol) { this.underlyingSymbol = underlyingSymbol; }
+
+    public int getLotSize() { return lotSize; }
+    public void setLotSize(int lotSize) { this.lotSize = lotSize; }
+
+    public double getFreezeQuantity() { return freezeQuantity; }
+    public void setFreezeQuantity(double freezeQuantity) { this.freezeQuantity = freezeQuantity; }
+
+    public String getExchangeToken() { return exchangeToken; }
+    public void setExchangeToken(String exchangeToken) { this.exchangeToken = exchangeToken; }
+
+    public int getMinimumLot() { return minimumLot; }
+    public void setMinimumLot(int minimumLot) { this.minimumLot = minimumLot; }
+
+    public String getAssetKey() { return assetKey; }
+    public void setAssetKey(String assetKey) { this.assetKey = assetKey; }
+
+    public String getUnderlyingKey() { return underlyingKey; }
+    public void setUnderlyingKey(String underlyingKey) { this.underlyingKey = underlyingKey; }
+
+    public double getTickSize() { return tickSize; }
+    public void setTickSize(double tickSize) { this.tickSize = tickSize; }
+
+    public String getAssetType() { return assetType; }
+    public void setAssetType(String assetType) { this.assetType = assetType; }
+
+    public String getUnderlyingType() { return underlyingType; }
+    public void setUnderlyingType(String underlyingType) { this.underlyingType = underlyingType; }
+
+    public String getTradingSymbol() { return tradingSymbol; }
+    public void setTradingSymbol(String tradingSymbol) { this.tradingSymbol = tradingSymbol; }
+
+    public double getQtyMultiplier() { return qtyMultiplier; }
+    public void setQtyMultiplier(double qtyMultiplier) { this.qtyMultiplier = qtyMultiplier; }
 }
 


### PR DESCRIPTION
## Summary
- provide explicit getters and setters for NseInstrument so callers use camelCase accessors

## Testing
- `./mvnw clean compile -q` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b13ae30d7c832f9199107eee01310d