### PR TITLE
Add Instant overload for expiry selection and fix caller

### DIFF
--- a/src/main/java/com/trader/backend/service/ExpirySelectorService.java
+++ b/src/main/java/com/trader/backend/service/ExpirySelectorService.java
@@ -63,5 +63,13 @@ public class ExpirySelectorService {
         }
         return next;
     }
+
+    public LocalDate pickCurrentExpiry(ZonedDateTime nowIst) {
+        return selectCurrentOptionExpiry(nowIst);
+    }
+
+    public LocalDate pickCurrentExpiry(Instant nowUtc) {
+        return pickCurrentExpiry(ZonedDateTime.ofInstant(nowUtc, IST));
+    }
 }
 

--- a/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -729,8 +729,8 @@ public Optional<String> nearestNiftyFutureKey() {
         log.info("🔁 Refreshing nse_instruments with CURRENT-WEEK NIFTY CE/PE from NSE.json...");
         try {
             ensureNseJsonLoaded(false);
-
-            LocalDate expiry = expirySelectorService.pickCurrentExpiry(Instant.now());
+            ZonedDateTime nowIst = ZonedDateTime.now(IST);
+            LocalDate expiry = expirySelectorService.pickCurrentExpiry(nowIst);
             long start = istStartOfDayMs(expiry);
             long end = istEndOfDayMs(expiry);
 


### PR DESCRIPTION
## Summary
- add Instant-based overload to ExpirySelectorService and delegate to existing logic
- convert NseInstrumentService to use IST ZonedDateTime before selecting expiry

## Testing
- `./mvnw clean package -DskipTests -DskipFrontend=true` *(fails: Non-resolvable parent POM for com.trader:backend:0.0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68b14b6acd28832f9cecb2e0eee93451