### PR TITLE
Fix embedded Mongo dependency version for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,10 @@
 
         <properties>
                 <java.version>17</java.version>
+                <de.flapdoodle.embed.mongo.version>4.12.2</de.flapdoodle.embed.mongo.version>
                 <!-- align your Protobuf versions here -->
                 <protoc.version>3.21.12</protoc.version>
+                <maven.compiler.release>17</maven.compiler.release>
                 <!-- Skip frontend build by default to avoid requiring Node during CI -->
                 <skipFrontend>true</skipFrontend>
         </properties>
@@ -106,7 +108,9 @@
                 <dependency>
                         <groupId>de.flapdoodle.embed</groupId>
                         <artifactId>de.flapdoodle.embed.mongo</artifactId>
+                        <version>${de.flapdoodle.embed.mongo.version}</version>
                         <scope>test</scope>
+                        <optional>true</optional>
                 </dependency>
 
 


### PR DESCRIPTION
## Summary
- pin embedded Mongo test dependency version and optional test scope
- specify Java release property for Maven compiler

## Testing
- `./mvnw -q -e clean package -DskipTests -DskipFrontend=true` *(fails: Non-resolvable parent POM – Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b151b4c6f8832fb09ce7afffc48802