### PR TITLE
Ensure camelCase test accessors and expiry overload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
                         <artifactId>spring-boot-starter-data-mongodb</artifactId>
                 </dependency>
 
+                <!-- Embedded MongoDB for tests -->
                 <dependency>
                         <groupId>de.flapdoodle.embed</groupId>
                         <artifactId>de.flapdoodle.embed.mongo</artifactId>

--- a/src/main/java/com/trader/backend/service/ExpirySelectorService.java
+++ b/src/main/java/com/trader/backend/service/ExpirySelectorService.java
@@ -69,7 +69,7 @@ public class ExpirySelectorService {
     }
 
     public LocalDate pickCurrentExpiry(Instant nowUtc) {
-        return pickCurrentExpiry(ZonedDateTime.ofInstant(nowUtc, IST));
+        return selectCurrentOptionExpiry(ZonedDateTime.ofInstant(nowUtc, IST));
     }
 
     /**

--- a/src/test/java/com/trader/backend/service/NseInstrumentServiceIntegrationTest.java
+++ b/src/test/java/com/trader/backend/service/NseInstrumentServiceIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.trader.backend.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trader.backend.entity.NseInstrument;
 import com.trader.backend.repository.NseInstrumentRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,7 @@ import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataMongoTest
@@ -31,5 +33,12 @@ public class NseInstrumentServiceIntegrationTest {
     void loadsAndPersistsCurrentWeekOptions() {
         NseInstrumentService.OptionBatch batch = service.loadCurrentWeekOptionInstruments();
         assertTrue(repo.countByExpiry(batch.expiry()) > 0);
+    }
+
+    @Test
+    void entityUsesCamelCaseAccessors() {
+        NseInstrument n = new NseInstrument();
+        n.setInstrumentKey("TEST");
+        assertEquals("TEST", n.getInstrumentKey());
     }
 }


### PR DESCRIPTION
## Summary
- verify NseInstrument camelCase accessors in integration test
- simplify pickCurrentExpiry overload using Instant
- document embedded MongoDB test dependency

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b16d0276a4832fa4c78b8ec7f95779