### PR TITLE
Remove duplicate morning refresh schedule

### DIFF
--- a/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -276,11 +276,6 @@ public class NseInstrumentService {
         return new OptionBatch(chosenEpochMs, ce, pe);
     }
 
-    @Scheduled(cron = "0 0 8 * * MON-FRI", zone = "Asia/Kolkata")
-    public void morningRefresh() {
-        loadCurrentWeekOptionInstruments();
-    }
-
     @Scheduled(cron = "0 35 15 * * MON-FRI", zone = "Asia/Kolkata")
     public void postCloseRefresh() {
         loadCurrentWeekOptionInstruments();


### PR DESCRIPTION
## Summary
- remove redundant morningRefresh method in `NseInstrumentService` to avoid duplicate definition

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b171e30a70832f8ad996e44ac8a2e1