### PR TITLE
Preserve last market LTPs and quiet heartbeats after close

### DIFF
--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -176,9 +176,12 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
                     long opt = optWrites.getAndSet(0);
                     ticksLast60s.set(fut + opt);
                     String source = connected.get() ? "live" : "influx";
-                    log.info("HEARTBEAT market={} liveFut={} liveOpts={} writesFut={}/15s writesOpt={}/15s sourceUsed={} ceLoadedCount={} peLoadedCount={}",
-                            open ? "open" : "closed", futOn ? "on" : "off", optCount, fut, opt, source,
-                            ceLoadedCount.get(), peLoadedCount.get());
+                    if (open) {
+                        log.info(
+                                "HEARTBEAT market={} liveFut={} liveOpts={} writesFut={}/15s writesOpt={}/15s sourceUsed={} ceLoadedCount={} peLoadedCount={}",
+                                "open", futOn ? "on" : "off", optCount, fut, opt, source,
+                                ceLoadedCount.get(), peLoadedCount.get());
+                    }
                 });
     }
 
@@ -847,7 +850,6 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
             optRows++;
         }
         log.info("MARKET CLOSED — last snapshot FUT={}, OPT rows={}", futPrice, optRows);
-        lastTick.clear();
         optionBuffers.clear();
         connected.set(false);
         futSubscribed.set(false);

--- a/src/main/java/com/trader/backend/service/LtpService.java
+++ b/src/main/java/com/trader/backend/service/LtpService.java
@@ -11,24 +11,18 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class LtpService {
     private final LiveFeedService liveFeedService;
-    private final InfluxTickService influxTickService;
 
     public record Result(Double ltp, Instant ts, String source) {}
 
     public Result resolve(String instrumentKey) {
         Instant now = Instant.now();
+        boolean marketOpen = liveFeedService.isMarketOpen();
         Optional<Tick> live = liveFeedService.getLatestTick(instrumentKey)
-                .filter(t -> Duration.between(t.ts(), now).toMillis() <= 5000);
+                .filter(t -> marketOpen ? Duration.between(t.ts(), now).toMillis() <= 5000 : true);
         if (live.isPresent()) {
             Tick t = live.get();
             liveFeedService.logResolvedLtp(instrumentKey, t.ltp(), "live");
             return new Result(t.ltp(), t.ts(), "live");
-        }
-        Optional<Tick> stored = influxTickService.latestTick(instrumentKey);
-        if (stored.isPresent()) {
-            Tick t = stored.get();
-            liveFeedService.logResolvedLtp(instrumentKey, t.ltp(), "stored");
-            return new Result(t.ltp(), t.ts(), "influx");
         }
         return new Result(null, null, "none");
     }


### PR DESCRIPTION
## Summary
- Suppress heartbeat logging when the market is closed
- Retain last ticks on market close so closing LTPs remain available
- Resolve LTPs only from live feed ticks, dropping the InfluxDB fallback

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bef2f625cc832faccc32ff133a8908