### PR TITLE
feat: use websocket cache for ltp

### DIFF
--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -823,7 +823,11 @@ private Flux<JsonNode> openWebSocketWithDynamicSub(String wsUrl, java.util.funct
                 label = info.getTradingSymbol();
             }
         }
-        log.info("LTP [{}] {}={}", label, source, ltp);
+        if ("NIFTY FUT".equals(label)) {
+            log.info("ltp for nifty future = {} ({}).", ltp, source);
+        } else {
+            log.info("LTP [{}] {}={}", label, source, ltp);
+        }
     }
 
     private void onMarketClose() {

--- a/src/main/java/com/trader/backend/service/LtpService.java
+++ b/src/main/java/com/trader/backend/service/LtpService.java
@@ -1,14 +1,22 @@
 package com.trader.backend.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
 
+/**
+ * Resolves the latest traded price for any instrument using the live
+ * WebSocket feed. If the feed is disconnected or stale, the last
+ * tick seen on the WebSocket is returned instead.
+ */
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class LtpService {
     private final LiveFeedService liveFeedService;
 
@@ -16,14 +24,21 @@ public class LtpService {
 
     public Result resolve(String instrumentKey) {
         Instant now = Instant.now();
-        boolean marketOpen = liveFeedService.isMarketOpen();
-        Optional<Tick> live = liveFeedService.getLatestTick(instrumentKey)
-                .filter(t -> marketOpen ? Duration.between(t.ts(), now).toMillis() <= 5000 : true);
-        if (live.isPresent()) {
-            Tick t = live.get();
-            liveFeedService.logResolvedLtp(instrumentKey, t.ltp(), "live");
-            return new Result(t.ltp(), t.ts(), "live");
+        Optional<Tick> tickOpt = liveFeedService.getLatestTick(instrumentKey);
+        if (tickOpt.isEmpty()) {
+            return new Result(null, null, "none");
         }
-        return new Result(null, null, "none");
+
+        Tick t = tickOpt.get();
+        boolean connected = liveFeedService.isConnected();
+        boolean marketOpen = liveFeedService.isMarketOpen();
+        boolean recent = Duration.between(t.ts(), now).toMillis() <= 5000;
+
+        String source = (connected && marketOpen && recent) ? "live" : "ws-cache";
+        liveFeedService.logResolvedLtp(instrumentKey, t.ltp(), source);
+        if ("ws-cache".equals(source)) {
+            log.info("ltp for nifty future = {}", t.ltp());
+        }
+        return new Result(t.ltp(), t.ts(), source);
     }
 }


### PR DESCRIPTION
## Summary
- resolve LTPs using websocket cache when live feed is disconnected
- log "ltp for nifty future" when resolving cached values

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bf03982464832faaf9e12e57971c52