### PR TITLE
Debounce FUT refresh and improve degraded responses

### DIFF
--- a/src/main/java/com/trader/backend/controller/MdController.java
+++ b/src/main/java/com/trader/backend/controller/MdController.java
@@ -159,15 +159,20 @@ public class MdController {
     public ResponseEntity<Map<String, Object>> ltp(@RequestParam("instrumentKey") String instrumentKey) {
         LtpService.Result res = ltpService.resolve(instrumentKey);
         Double val = res.ltp();
-        log.info("LTP {} via {} value={} ts={}", instrumentKey, res.source(), val, res.ts());
+        boolean degraded = val == null || res.ts() == null;
+        if (degraded) {
+            log.info("GET /md/ltp instrumentKey={} src={} degraded=true", instrumentKey, res.source());
+            log.debug("GET /md/ltp instrumentKey={} src={} value={} ts={}", instrumentKey, res.source(), val, res.ts());
+        } else {
+            log.info("GET /md/ltp instrumentKey={} src={} value={} ts={} degraded=false", instrumentKey, res.source(), val, res.ts());
+        }
 
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("instrumentKey", instrumentKey);
         body.put("source", res.source());
-        if (val != null) {
+        body.put("degraded", degraded);
+        if (!degraded) {
             body.put("ltp", val);
-        }
-        if (res.ts() != null) {
             body.put("ts", res.ts().toString());
         }
         return ResponseEntity.ok()

--- a/src/main/java/com/trader/backend/service/LiveFeedService.java
+++ b/src/main/java/com/trader/backend/service/LiveFeedService.java
@@ -155,6 +155,9 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
     }
     @PostConstruct
     public void subscribeToAuthEvents() {
+        if (writeApi == null) {
+            log.debug("FUT write path disabled (counters suppressed)");
+        }
         auth.events()
                 .filter(e -> e == UpstoxAuthService.AuthEvent.READY)
                 .subscribe(ev -> {
@@ -505,23 +508,35 @@ private final Set<String> currentlySubscribedKeys = ConcurrentHashMap.newKeySet(
     public Flux<JsonNode> openWebSocketForOptions(String wsUrl, byte[] subFrame) {
         ReactorNettyWebSocketClient client = createWsClient();
         Sinks.Many<JsonNode> local = Sinks.many().multicast().onBackpressureBuffer();
+        AtomicInteger attempt = new AtomicInteger(0);
 
-        client.execute(URI.create(wsUrl), session -> {
-            Flux<WebSocketMessage> pings = Flux.interval(Duration.ofSeconds(25))
-                    .map(i -> session.pingMessage(factory -> factory.wrap(new byte[0])));
-            session.send(pings).subscribe();
+        Runnable connect = new Runnable() {
+            @Override
+            public void run() {
+                client.execute(URI.create(wsUrl), session -> {
+                    Flux<WebSocketMessage> pings = Flux.interval(Duration.ofSeconds(30))
+                            .map(i -> session.pingMessage(factory -> factory.wrap(new byte[0])));
+                    session.send(pings).subscribe();
 
-            return session.send(Mono.just(session.binaryMessage(bb -> bb.wrap(subFrame))))
-                    .doOnSuccess(v -> log.info("▶︎ Nifty options subscription frame sent"))
-                    .thenMany(session.receive()
-                            .map(WebSocketMessage::getPayload)
-                            .map(this::parseProtoFeedResponse)
-                            .doOnNext(local::tryEmitNext)
-                            .doOnSubscribe(s -> log.info("📡 Subscribed to Nifty options WebSocket feed"))
+                    return session.send(Mono.just(session.binaryMessage(bb -> bb.wrap(subFrame))))
+                            .doOnSuccess(v -> log.info("▶︎ Nifty options subscription frame sent"))
+                            .thenMany(session.receive()
+                                    .map(WebSocketMessage::getPayload)
+                                    .map(LiveFeedService.this::parseProtoFeedResponse)
+                                    .doOnNext(local::tryEmitNext)
+                                    .doOnSubscribe(s -> log.info("📡 Subscribed to Nifty options WebSocket feed")))
+                            .doOnError(err -> log.error("❌ WebSocket stream failed:", err))
+                            .doFinally(sig -> {
+                                int delay = nextDelay(attempt.incrementAndGet());
+                                log.info("LIVE DISCONNECTED → reconnecting in {}s", delay);
+                                Mono.delay(Duration.ofSeconds(delay)).subscribe(i -> run());
+                            })
+                            .then();
+                }).subscribe();
+            }
+        };
 
-                    )
-                    .then();
-        }).subscribe();
+        connect.run();
 
         return local.asFlux();
     }

--- a/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -87,7 +87,9 @@ public class NseInstrumentService {
 
     // ensure heavy CE/PE filtering runs once
     private final AtomicBoolean strikesFiltered = new AtomicBoolean(false);
+    private static final long REFRESH_MIN_INTERVAL = 60_000L;
     private volatile long lastFutRefreshMs = 0L;
+    private final AtomicBoolean futExpiryLogged = new AtomicBoolean(false);
 
     /** Ensure NSE.json is loaded into memory. */
     public synchronized void ensureNseJsonLoaded(boolean force) {
@@ -724,6 +726,7 @@ public void saveNiftyFuturesToMongo() {
         mongoTemplate.indexOps("nifty_futures")
                 .ensureIndex(new org.springframework.data.mongodb.core.index.Index().on("expiry", Sort.Direction.ASC));
         log.info("💾 Upserted {} NIFTY FUT records into MongoDB collection: nifty_futures (indexed on expiry)", niftyFutures.size());
+        futExpiryLogged.set(false);
     } else {
         log.warn("⚠️ No matching NIFTY FUT records found.");
     }
@@ -746,12 +749,15 @@ Optional<NseInstrument> selectCurrentNiftyFuture(List<NseInstrument> futs) {
             .sorted(Comparator.comparingLong(NseInstrument::getExpiry))
             .toList();
 
+    boolean logOnce = futExpiryLogged.compareAndSet(false, true);
     for (NseInstrument f : sorted) {
         LocalDate d = Instant.ofEpochMilli(f.getExpiry()).atZone(IST).toLocalDate();
         ZonedDateTime cutoff = d.atTime(EXPIRY_CUTOFF).atZone(IST);
         boolean expired = now.isAfter(cutoff);
         String month = extractMonth(f.getTradingSymbol());
-        log.info("📄 {} | expiry={} IST {}", f.getTradingSymbol(), cutoff, expired ? "[expired]" : "[valid]");
+        if (logOnce) {
+            log.info("📄 {} | expiry={} IST {}", f.getTradingSymbol(), cutoff, expired ? "[expired]" : "[valid]");
+        }
         if (expired) {
             otherStatuses.add(month + " expired");
         } else if (chosen == null) {
@@ -844,12 +850,14 @@ private synchronized void refreshNiftyFuturesIfNeeded() {
     if (mongoTemplate.count(q, "nifty_futures") > 0) {
         return; // already have valid futures
     }
-    if (now - lastFutRefreshMs < 60_000L) {
+    if (now - lastFutRefreshMs < REFRESH_MIN_INTERVAL) {
         return; // debounce reload attempts
     }
-    lastFutRefreshMs = now;
     log.warn("⚠️ No future NIFTY FUT contracts found. Reloading from JSON...");
     saveNiftyFuturesToMongo();
+    if (mongoTemplate.count(q, "nifty_futures") > 0) {
+        lastFutRefreshMs = now;
+    }
 }
 
 public Optional<String> nearestNiftyFutureKey() {
@@ -868,12 +876,14 @@ public Optional<String> nearestNiftyFutureKey() {
             Criteria.where("lot_size").is(75)
     )).with(Sort.by(Sort.Direction.ASC, "expiry")).limit(3);
     List<NseInstrument> top = mongoTemplate.find(logQ, NseInstrument.class, "nifty_futures");
-    top.forEach(f -> {
-        LocalDate d = Instant.ofEpochMilli(f.getExpiry()).atZone(IST).toLocalDate();
-        ZonedDateTime cutoff = d.atTime(EXPIRY_CUTOFF).atZone(IST);
-        boolean expired = now.isAfter(cutoff);
-        log.info("📄 {} | expiry={} IST {}", f.getTradingSymbol(), cutoff, expired ? "[expired]" : "[valid]");
-    });
+    if (futExpiryLogged.compareAndSet(false, true)) {
+        top.forEach(f -> {
+            LocalDate d = Instant.ofEpochMilli(f.getExpiry()).atZone(IST).toLocalDate();
+            ZonedDateTime cutoff = d.atTime(EXPIRY_CUTOFF).atZone(IST);
+            boolean expired = now.isAfter(cutoff);
+            log.info("📄 {} | expiry={} IST {}", f.getTradingSymbol(), cutoff, expired ? "[expired]" : "[valid]");
+        });
+    }
 
     // query DB for nearest non-expired future
     Query q = new Query(new Criteria().andOperator(


### PR DESCRIPTION
## Summary
- Debounce NIFTY FUT reloads with 60s guard and log futures once per refresh
- Return degraded payloads for LTP endpoint
- Add FUT write-path notice and WebSocket keepalive/reconnect logic

## Testing
- ⚠️ `mvn -q test` *(failed: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c11132df5c832fbe4fc0da5ba555ba