### PR TITLE
Add market streaming endpoints and instrument refresh workflow

### DIFF
--- a/src/main/java/com/trader/backend/entity/NseInstrument.java
+++ b/src/main/java/com/trader/backend/entity/NseInstrument.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -34,10 +35,12 @@ public class NseInstrument {
 
     @JsonProperty("expiry")
     @Field("expiry")
+    @Indexed
     private long expiry;
 
     @JsonProperty("instrument_type")
     @Field("instrument_type")
+    @Indexed
     private String instrumentType;
 
     @JsonProperty("strike_price")
@@ -74,6 +77,7 @@ public class NseInstrument {
 
     @JsonProperty("underlying_key")
     @Field("underlying_key")
+    @Indexed
     private String underlyingKey;
 
     @JsonProperty("tick_size")
@@ -90,6 +94,7 @@ public class NseInstrument {
 
     @JsonProperty("trading_symbol")
     @Field("trading_symbol")
+    @Indexed
     private String tradingSymbol;
 
     @JsonProperty("qty_multiplier")

--- a/src/main/java/com/trader/backend/market/InstrumentRefreshController.java
+++ b/src/main/java/com/trader/backend/market/InstrumentRefreshController.java
@@ -1,0 +1,148 @@
+package com.trader.backend.market;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.bulk.BulkWriteResult;
+import com.trader.backend.entity.NseInstrument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.BulkOperations;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+@RestController
+@RequestMapping("/api/instruments")
+@RequiredArgsConstructor
+@Slf4j
+public class InstrumentRefreshController {
+
+    private static final TypeReference<List<NseInstrument>> LIST_TYPE = new TypeReference<>() {
+    };
+
+    private final MongoTemplate mongoTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${app.instruments.nse-json:}")
+    private String instrumentsPath;
+
+    @PostMapping("/refresh")
+    public MarketDtos.RefreshResult refresh() {
+        try {
+            List<NseInstrument> all = loadInstruments();
+            int total = all.size();
+            List<NseInstrument> filtered = all.stream()
+                    .filter(this::isEligible)
+                    .toList();
+            ensureIndexes();
+            if (filtered.isEmpty()) {
+                log.info("event=INSTRUMENT_REFRESH_COMPLETED processed=0 upserted=0 skipped={}", total);
+                return new MarketDtos.RefreshResult(0, 0, total);
+            }
+
+            BulkOperations ops = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, NseInstrument.class);
+            int scheduled = 0;
+            for (NseInstrument instrument : filtered) {
+                if (!StringUtils.hasText(instrument.getInstrumentKey())) {
+                    continue;
+                }
+                Document document = new Document();
+                mongoTemplate.getConverter().write(instrument, document);
+                Object id = document.remove("_id");
+                if (id == null) {
+                    id = instrument.getInstrumentKey();
+                }
+                Query query = Query.query(Criteria.where("_id").is(id));
+                ops.upsert(query, Update.fromDocument(document));
+                scheduled++;
+            }
+
+            int upserted = 0;
+            if (scheduled > 0) {
+                BulkWriteResult result = ops.execute();
+                upserted = result.getUpserts().size() + result.getModifiedCount();
+            }
+            int processed = filtered.size();
+            int skipped = total - processed;
+            log.info("event=INSTRUMENT_REFRESH_COMPLETED processed={} upserted={} skipped={}", processed, upserted, skipped);
+            return new MarketDtos.RefreshResult(processed, upserted, skipped);
+        } catch (IOException e) {
+            log.error("event=INSTRUMENT_REFRESH_FAILED reason={}", e.getMessage(), e);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to refresh instruments");
+        }
+    }
+
+    private List<NseInstrument> loadInstruments() throws IOException {
+        try (InputStream inputStream = resolveInputStream()) {
+            return objectMapper.readValue(inputStream, LIST_TYPE);
+        }
+    }
+
+    private InputStream resolveInputStream() throws IOException {
+        if (StringUtils.hasText(instrumentsPath)) {
+            Path path = Path.of(instrumentsPath);
+            if (Files.exists(path)) {
+                log.info("Loading instruments from configured path: {}", path);
+                return Files.newInputStream(path);
+            }
+            log.warn("Configured NSE.json path not found: {}", path);
+        }
+        InputStream resourceStream = InstrumentRefreshController.class.getClassLoader().getResourceAsStream("data/NSE.json");
+        if (resourceStream != null) {
+            return resourceStream;
+        }
+        throw new FileNotFoundException("Unable to locate NSE.json");
+    }
+
+    private boolean isEligible(NseInstrument instrument) {
+        if (instrument == null) {
+            return false;
+        }
+        String segment = instrument.getSegment();
+        if (!StringUtils.hasText(segment)) {
+            return false;
+        }
+        if ("NSE_EQ".equalsIgnoreCase(segment)) {
+            return true;
+        }
+        if ("NSE_FO".equalsIgnoreCase(segment)) {
+            String underlying = instrument.getUnderlyingSymbol();
+            String name = instrument.getName();
+            return (StringUtils.hasText(underlying) && underlying.equalsIgnoreCase("NIFTY"))
+                    || (StringUtils.hasText(name) && name.toUpperCase(Locale.ROOT).contains("NIFTY"));
+        }
+        if ("NSE_INDEX".equalsIgnoreCase(segment)) {
+            String name = instrument.getName();
+            return StringUtils.hasText(name) && name.toUpperCase(Locale.ROOT).contains("NIFTY");
+        }
+        return false;
+    }
+
+    private void ensureIndexes() {
+        IndexOperations indexOps = mongoTemplate.indexOps(NseInstrument.class);
+        indexOps.ensureIndex(new Index().on("expiry", Sort.Direction.ASC));
+        indexOps.ensureIndex(new Index().on("instrument_type", Sort.Direction.ASC));
+        indexOps.ensureIndex(new Index().on("underlying_key", Sort.Direction.ASC));
+        indexOps.ensureIndex(new Index().on("trading_symbol", Sort.Direction.ASC));
+    }
+}

--- a/src/main/java/com/trader/backend/market/InstrumentSearchController.java
+++ b/src/main/java/com/trader/backend/market/InstrumentSearchController.java
@@ -1,0 +1,65 @@
+package com.trader.backend.market;
+
+import com.trader.backend.entity.NseInstrument;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+@RestController
+@RequestMapping("/api/instruments")
+@RequiredArgsConstructor
+@Slf4j
+public class InstrumentSearchController {
+
+    private static final int MAX_LIMIT = 100;
+
+    private final MongoTemplate mongoTemplate;
+
+    @GetMapping("/search")
+    public List<MarketDtos.InstrumentHit> search(@RequestParam("q") String query,
+                                                 @RequestParam(value = "limit", defaultValue = "20") int limit) {
+        if (!StringUtils.hasText(query)) {
+            return List.of();
+        }
+        int sanitizedLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
+        String sanitizedQuery = query.trim();
+        Pattern pattern = Pattern.compile(Pattern.quote(sanitizedQuery), Pattern.CASE_INSENSITIVE);
+        Criteria criteria = new Criteria().orOperator(
+                Criteria.where("trading_symbol").regex(pattern),
+                Criteria.where("name").regex(pattern)
+        );
+        Query mongoQuery = Query.query(criteria)
+                .limit(sanitizedLimit)
+                .with(Sort.by(Sort.Direction.ASC, "trading_symbol"));
+        List<NseInstrument> results = mongoTemplate.find(mongoQuery, NseInstrument.class, "nse_instruments");
+        return results.stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    private MarketDtos.InstrumentHit toDto(NseInstrument instrument) {
+        String display = StringUtils.hasText(instrument.getName()) ? instrument.getName() : instrument.getTradingSymbol();
+        String symbol = StringUtils.hasText(instrument.getTradingSymbol()) ? instrument.getTradingSymbol() : instrument.getAssetSymbol();
+        Long expiry = instrument.getExpiry() > 0 ? instrument.getExpiry() : null;
+        return new MarketDtos.InstrumentHit(
+                display,
+                instrument.getInstrumentKey(),
+                instrument.getSegment(),
+                symbol,
+                expiry,
+                instrument.getStrikePrice(),
+                instrument.getInstrumentType()
+        );
+    }
+}

--- a/src/main/java/com/trader/backend/market/MarketDtos.java
+++ b/src/main/java/com/trader/backend/market/MarketDtos.java
@@ -1,0 +1,67 @@
+package com.trader.backend.market;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+public final class MarketDtos {
+
+    private MarketDtos() {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record NormalizedTick(
+            String type,
+            long ts,
+            String instrumentKey,
+            double ltp,
+            Double ltq,
+            Long ltt,
+            Double cp,
+            List<BidAskQuote> bidAsk,
+            Double oi,
+            Greeks greeks,
+            Ohlc ohlc
+    ) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record BidAskQuote(double bidP, double bidQ, double askP, double askQ) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Greeks(Double delta, Double theta, Double gamma, Double vega, Double rho) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Ohlc(OhlcEntry d1, OhlcEntry i1) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record OhlcEntry(Double o, Double h, Double l, Double c, Object v, Long ts) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record MarketHistoryResponse(String instrumentKey, String tf, List<Candle> candles) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record Candle(long ts, double o, double h, double l, double c, double v) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record InstrumentHit(
+            String display,
+            String instrumentKey,
+            String segment,
+            String symbol,
+            Long expiry,
+            Integer strikePrice,
+            String instrumentType
+    ) {
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record RefreshResult(int processed, int upserted, int skipped) {
+    }
+}

--- a/src/main/java/com/trader/backend/market/MarketHistoryController.java
+++ b/src/main/java/com/trader/backend/market/MarketHistoryController.java
@@ -1,0 +1,118 @@
+package com.trader.backend.market;
+
+import com.trader.backend.service.CandleService;
+import com.trader.backend.service.CandleService.Candle;
+import com.trader.backend.service.CandleService.CandleResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.ThreadLocalRandom;
+
+@RestController
+@RequestMapping("/api/market")
+@Slf4j
+public class MarketHistoryController {
+
+    private final CandleService candleService;
+
+    public MarketHistoryController(ObjectProvider<CandleService> candleServiceProvider) {
+        this.candleService = candleServiceProvider.getIfAvailable();
+    }
+
+    @GetMapping("/history")
+    public Mono<MarketDtos.MarketHistoryResponse> history(@RequestParam("instrumentKey") String instrumentKey,
+                                                          @RequestParam(value = "tf", defaultValue = "1m") String timeframe,
+                                                          @RequestParam(value = "limit", defaultValue = "300") int limit) {
+        if (!StringUtils.hasText(instrumentKey)) {
+            return Mono.error(new IllegalArgumentException("instrumentKey is required"));
+        }
+
+        int sanitizedLimit = Math.min(Math.max(limit, 1), 1000);
+        String normalizedTf = normalizeTf(timeframe);
+        boolean influxSupported = !"1s".equalsIgnoreCase(timeframe);
+
+        if (candleService == null || !influxSupported) {
+            log.debug("Returning dummy history for instrumentKey={} tf={}", instrumentKey, timeframe);
+            return Mono.just(dummyHistory(instrumentKey, timeframe, sanitizedLimit));
+        }
+
+        return candleService.fetchCandles(List.of(instrumentKey), normalizedTf, sanitizedLimit)
+                .map(responses -> responses.isEmpty() ? null : responses.get(0))
+                .flatMap(response -> {
+                    if (response == null || response.candles().isEmpty()) {
+                        log.debug("No historical candles available from Influx for instrumentKey={} tf={}", instrumentKey, normalizedTf);
+                        return Mono.just(dummyHistory(instrumentKey, timeframe, sanitizedLimit));
+                    }
+                    return Mono.just(fromResponse(instrumentKey, timeframe, response));
+                })
+                .onErrorResume(ex -> {
+                    log.warn("Falling back to dummy history for instrumentKey={} tf={} reason={}", instrumentKey, timeframe, ex.getMessage());
+                    return Mono.just(dummyHistory(instrumentKey, timeframe, sanitizedLimit));
+                });
+    }
+
+    private String normalizeTf(String tf) {
+        String normalized = tf == null ? "1m" : tf.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "5m" -> "5m";
+            case "15m" -> "15m";
+            case "3m" -> "3m";
+            default -> "1m";
+        };
+    }
+
+    private MarketDtos.MarketHistoryResponse fromResponse(String instrumentKey, String requestedTf, CandleResponse response) {
+        List<MarketDtos.Candle> candles = new ArrayList<>(response.candles().size());
+        for (Candle candle : response.candles()) {
+            try {
+                Instant ts = Instant.parse(candle.t());
+                candles.add(new MarketDtos.Candle(
+                        ts.toEpochMilli(),
+                        candle.o(),
+                        candle.h(),
+                        candle.l(),
+                        candle.c(),
+                        candle.v()
+                ));
+            } catch (DateTimeParseException e) {
+                log.debug("Skipping candle with unparsable timestamp: {}", candle.t());
+            }
+        }
+        return new MarketDtos.MarketHistoryResponse(instrumentKey, requestedTf, candles);
+    }
+
+    private MarketDtos.MarketHistoryResponse dummyHistory(String instrumentKey, String timeframe, int limit) {
+        Duration step = switch (timeframe.toLowerCase(Locale.ROOT)) {
+            case "1s" -> Duration.ofSeconds(1);
+            case "5m" -> Duration.ofMinutes(5);
+            default -> Duration.ofMinutes(1);
+        };
+        List<MarketDtos.Candle> candles = new ArrayList<>(limit);
+        Instant now = Instant.now();
+        double price = 100.0 + ThreadLocalRandom.current().nextDouble(10.0);
+        for (int i = limit; i >= 1; i--) {
+            Instant ts = now.minus(step.multipliedBy(i));
+            double drift = ThreadLocalRandom.current().nextDouble(-1.5, 1.5);
+            double open = price;
+            double close = Math.max(1.0, open + drift);
+            double high = Math.max(open, close) + ThreadLocalRandom.current().nextDouble(0.5);
+            double low = Math.min(open, close) - ThreadLocalRandom.current().nextDouble(0.5);
+            double volume = 50 + ThreadLocalRandom.current().nextDouble(250.0);
+            candles.add(new MarketDtos.Candle(ts.toEpochMilli(), open, high, low, close, volume));
+            price = close;
+        }
+        return new MarketDtos.MarketHistoryResponse(instrumentKey, timeframe, candles);
+    }
+}

--- a/src/main/java/com/trader/backend/market/MarketWebSocketController.java
+++ b/src/main/java/com/trader/backend/market/MarketWebSocketController.java
@@ -1,0 +1,153 @@
+package com.trader.backend.market;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.trader.backend.service.LiveFeedService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.CloseStatus;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@Configuration
+@RequiredArgsConstructor
+@Slf4j
+public class MarketWebSocketController {
+
+    private final LiveFeedService liveFeedService;
+    private final TickNormalizer tickNormalizer;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public HandlerMapping marketWebSocketMapping(WebSocketHandler marketWebSocketHandler) {
+        SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
+        mapping.setOrder(-1);
+        mapping.setUrlMap(Map.of("/ws/market", marketWebSocketHandler));
+        return mapping;
+    }
+
+    @Bean
+    public WebSocketHandler marketWebSocketHandler() {
+        return new MarketSocketHandler(liveFeedService, tickNormalizer, objectMapper);
+    }
+
+    @Bean
+    public WebSocketHandlerAdapter marketWebSocketHandlerAdapter() {
+        return new WebSocketHandlerAdapter();
+    }
+
+    static final class MarketSocketHandler implements WebSocketHandler {
+
+        private final LiveFeedService liveFeedService;
+        private final TickNormalizer tickNormalizer;
+        private final ObjectMapper objectMapper;
+
+        MarketSocketHandler(LiveFeedService liveFeedService,
+                            TickNormalizer tickNormalizer,
+                            ObjectMapper objectMapper) {
+            this.liveFeedService = liveFeedService;
+            this.tickNormalizer = tickNormalizer;
+            this.objectMapper = objectMapper;
+        }
+
+        @Override
+        public Mono<Void> handle(WebSocketSession session) {
+            Set<String> keys = extractKeys(session.getHandshakeInfo().getUri());
+            if (CollectionUtils.isEmpty(keys)) {
+                log.warn("event=CLIENT_WS_REJECTED instrumentKey=NONE reason=missing_keys");
+                return session.close(CloseStatus.PROTOCOL_ERROR);
+            }
+
+            String joinedKeys = String.join(",", keys);
+            log.info("event=CLIENT_WS_CONNECTED instrumentKey={}", joinedKeys);
+
+            Flux<MarketDtos.NormalizedTick> normalizedFlux = liveFeedService.stream()
+                    .flatMap(tick -> filterAndNormalize(tick, keys))
+                    .doOnNext(t -> log.info("event=TICK_EMITTED instrumentKey={}", t.instrumentKey()));
+
+            Flux<WebSocketMessage> outbound = normalizedFlux
+                    .map(tick -> toMessage(session, tick))
+                    .filter(Objects::nonNull);
+
+            Mono<Void> send = session.send(outbound)
+                    .doOnError(err -> log.error("event=CLIENT_WS_SEND_FAILED instrumentKey={} reason={}", joinedKeys, err.getMessage()));
+
+            Mono<Void> receive = session.receive()
+                    .doOnError(err -> log.error("event=CLIENT_WS_RECEIVE_FAILED instrumentKey={} reason={}", joinedKeys, err.getMessage()))
+                    .then();
+
+            return Mono.when(send, receive)
+                    .doFinally(signalType -> log.info("event=CLIENT_WS_DISCONNECTED instrumentKey={}", joinedKeys));
+        }
+
+        private Flux<MarketDtos.NormalizedTick> filterAndNormalize(JsonNode tick, Set<String> keys) {
+            JsonNode feeds = tick.path("feeds");
+            if (feeds.isMissingNode() || feeds.isNull()) {
+                return Flux.empty();
+            }
+            List<MarketDtos.NormalizedTick> results = new ArrayList<>();
+            for (String key : keys) {
+                JsonNode feed = feeds.path(key);
+                if (feed.isMissingNode() || feed.isNull()) {
+                    continue;
+                }
+                log.info("event=UPSTREAM_TICK_RCVD instrumentKey={}", key);
+                tickNormalizer.normalize(key, feed, tick).ifPresent(results::add);
+            }
+            return Flux.fromIterable(results);
+        }
+
+        private WebSocketMessage toMessage(WebSocketSession session, MarketDtos.NormalizedTick tick) {
+            try {
+                String json = objectMapper.writeValueAsString(tick);
+                return session.textMessage(json);
+            } catch (JsonProcessingException e) {
+                log.error("event=TICK_SERIALIZATION_FAILED instrumentKey={} reason={}", tick.instrumentKey(), e.getMessage());
+                return null;
+            }
+        }
+
+        private Set<String> extractKeys(URI uri) {
+            MultiValueMap<String, String> queryParams = UriComponentsBuilder.fromUri(uri).build().getQueryParams();
+            if (queryParams == null || queryParams.isEmpty()) {
+                return Set.of();
+            }
+            Set<String> keys = new LinkedHashSet<>();
+            List<String> rawKeys = queryParams.get("keys");
+            if (rawKeys != null) {
+                for (String raw : rawKeys) {
+                    if (raw == null) {
+                        continue;
+                    }
+                    for (String value : raw.split(",")) {
+                        String trimmed = value.trim();
+                        if (!trimmed.isEmpty()) {
+                            keys.add(trimmed);
+                        }
+                    }
+                }
+            }
+            return keys;
+        }
+    }
+}

--- a/src/main/java/com/trader/backend/market/TickNormalizer.java
+++ b/src/main/java/com/trader/backend/market/TickNormalizer.java
@@ -1,0 +1,223 @@
+package com.trader.backend.market;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+@Component
+@Slf4j
+public class TickNormalizer {
+
+    private static final long MILLIS_THRESHOLD = 1_000_000_000_000L;
+
+    public Optional<MarketDtos.NormalizedTick> normalize(String instrumentKey, JsonNode feed, JsonNode root) {
+        if (feed == null || feed.isMissingNode() || feed.isNull()) {
+            return Optional.empty();
+        }
+
+        JsonNode fullFeed = feed.path("fullFeed");
+        JsonNode marketFeed = fullFeed.path("marketFF");
+        boolean usingIndexFeed = false;
+        if (marketFeed.isMissingNode() || marketFeed.isNull() || marketFeed.isEmpty()) {
+            marketFeed = fullFeed.path("indexFF");
+            usingIndexFeed = !marketFeed.isMissingNode() && !marketFeed.isNull() && !marketFeed.isEmpty();
+        }
+
+        if (marketFeed.isMissingNode() || marketFeed.isNull() || marketFeed.isEmpty()) {
+            log.debug("No market feed for instrumentKey={}", instrumentKey);
+            return Optional.empty();
+        }
+
+        JsonNode ltpc = marketFeed.path("ltpc");
+        JsonNode ltpNode = ltpc.path("ltp");
+        if (!ltpNode.isNumber()) {
+            return Optional.empty();
+        }
+
+        double ltp = ltpNode.asDouble();
+        long ts = extractTimestamp(feed, root);
+        Double ltq = asDouble(ltpc.path("ltq"));
+        Long ltt = asLong(ltpc.path("ltt"));
+        Double cp = asDouble(ltpc.path("cp"));
+
+        List<MarketDtos.BidAskQuote> bidAsk = usingIndexFeed ? List.of() : parseBidAsk(marketFeed.path("marketLevel").path("bidAskQuote"));
+        Double oi = asDouble(marketFeed.path("oi"));
+        MarketDtos.Greeks greeks = parseGreeks(marketFeed.path("optionGreeks"));
+        MarketDtos.Ohlc ohlc = parseOhlc(marketFeed.path("marketOHLC").path("ohlc"));
+
+        if (bidAsk != null && bidAsk.isEmpty()) {
+            bidAsk = null;
+        }
+        if (greeks != null && greeks.delta() == null && greeks.theta() == null && greeks.gamma() == null
+                && greeks.vega() == null && greeks.rho() == null) {
+            greeks = null;
+        }
+        if (ohlc != null && ohlc.d1() == null && ohlc.i1() == null) {
+            ohlc = null;
+        }
+
+        return Optional.of(new MarketDtos.NormalizedTick(
+                "tick",
+                ts,
+                instrumentKey,
+                ltp,
+                ltq,
+                ltt,
+                cp,
+                bidAsk,
+                oi,
+                greeks,
+                ohlc
+        ));
+    }
+
+    private List<MarketDtos.BidAskQuote> parseBidAsk(JsonNode quotesNode) {
+        if (quotesNode == null || !quotesNode.isArray()) {
+            return null;
+        }
+        List<MarketDtos.BidAskQuote> quotes = new ArrayList<>();
+        for (JsonNode level : quotesNode) {
+            if (quotes.size() >= 5) {
+                break;
+            }
+            Double bidP = asDouble(level.path("bidP"));
+            Double bidQ = asDouble(level.path("bidQ"));
+            Double askP = asDouble(level.path("askP"));
+            Double askQ = asDouble(level.path("askQ"));
+            if (bidP == null && askP == null) {
+                continue;
+            }
+            quotes.add(new MarketDtos.BidAskQuote(
+                    bidP != null ? bidP : 0.0,
+                    bidQ != null ? bidQ : 0.0,
+                    askP != null ? askP : 0.0,
+                    askQ != null ? askQ : 0.0
+            ));
+        }
+        return quotes;
+    }
+
+    private MarketDtos.Greeks parseGreeks(JsonNode greeksNode) {
+        if (greeksNode == null || greeksNode.isMissingNode() || greeksNode.isNull() || greeksNode.isEmpty()) {
+            return null;
+        }
+        return new MarketDtos.Greeks(
+                asDouble(greeksNode.path("delta")),
+                asDouble(greeksNode.path("theta")),
+                asDouble(greeksNode.path("gamma")),
+                asDouble(greeksNode.path("vega")),
+                asDouble(greeksNode.path("rho"))
+        );
+    }
+
+    private MarketDtos.Ohlc parseOhlc(JsonNode ohlcNode) {
+        if (ohlcNode == null || !ohlcNode.isArray() || ohlcNode.isEmpty()) {
+            return null;
+        }
+        MarketDtos.OhlcEntry daily = null;
+        MarketDtos.OhlcEntry intraday = null;
+        for (JsonNode entry : ohlcNode) {
+            String interval = entry.path("interval").asText("").toLowerCase(Locale.ROOT);
+            MarketDtos.OhlcEntry normalized = new MarketDtos.OhlcEntry(
+                    asDouble(entry.path("open")),
+                    asDouble(entry.path("high")),
+                    asDouble(entry.path("low")),
+                    asDouble(entry.path("close")),
+                    extractVolume(entry.path("vol")),
+                    asLong(entry.path("ts"))
+            );
+            if (interval.isEmpty()) {
+                continue;
+            }
+            if (interval.equals("1d") || interval.equals("d1") || interval.contains("day")) {
+                daily = normalized;
+            } else if (interval.equals("1m") || interval.equals("i1") || interval.contains("min")) {
+                intraday = normalized;
+            }
+        }
+        return new MarketDtos.Ohlc(daily, intraday);
+    }
+
+    private Object extractVolume(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.asLong();
+        }
+        if (node.isTextual()) {
+            String txt = node.asText();
+            try {
+                return Long.parseLong(txt);
+            } catch (NumberFormatException ignored) {
+                return txt;
+            }
+        }
+        return null;
+    }
+
+    private Double asDouble(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            return node.asDouble();
+        }
+        if (node.isTextual()) {
+            try {
+                return Double.parseDouble(node.asText());
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private Long asLong(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        if (node.isNumber()) {
+            long value = node.asLong();
+            return adjustEpoch(value);
+        }
+        if (node.isTextual()) {
+            try {
+                long value = Long.parseLong(node.asText());
+                return adjustEpoch(value);
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private long extractTimestamp(JsonNode feed, JsonNode root) {
+        String[] ptrs = {"/fullFeed/marketFF/ts", "/fullFeed/ts", "/ts", "/timestamp"};
+        for (String ptr : ptrs) {
+            JsonNode node = feed.at(ptr);
+            if (node.isNumber() || node.isTextual()) {
+                Long value = asLong(node);
+                if (value != null) {
+                    return value;
+                }
+            }
+        }
+        JsonNode currentTs = root.path("currentTs");
+        Long value = asLong(currentTs);
+        if (value != null) {
+            return value;
+        }
+        return Instant.now().toEpochMilli();
+    }
+
+    private long adjustEpoch(long value) {
+        return value < MILLIS_THRESHOLD ? value * 1000L : value;
+    }
+}


### PR DESCRIPTION
## Summary
- add market DTOs, tick normalizer, and WebSocket handler that filters by requested instrument keys and emits a stable tick schema
- expose market history and instrument search endpoints with dummy history fallback when Influx is unavailable
- implement Mongo-backed instrument refresh with bulk upsert/index creation and annotate the entity with indexes

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download parent POM from Maven Central because the network is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c92f599d54832fa9e13c04657ff465