### PR TITLE
Update CORS configuration for frontend compatibility

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -2,46 +2,40 @@ package com.trader.backend.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import java.util.Arrays;
 import java.util.List;
-@ComponentScan
+import java.util.stream.Collectors;
+
 @Configuration
-@EnableWebMvc
 public class CorsConfig {
 
-    @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app,http://localhost:4200}")
-    private String allowedOrigins;
+  @Value("${cors.allowedOrigins:https://frontendfortheautobot.vercel.app,http://localhost:4200}")
+  private String allowedOrigins;
 
-    @Bean
-    public CorsFilter corsFilter() {
-        CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(false);
-        config.setAllowedOrigins(Arrays.asList(allowedOrigins.split(",")));
-        config.setAllowedHeaders(List.of("Content-Type"));
-        config.setAllowedMethods(List.of("GET"));
+  @Bean
+  public CorsFilter corsFilter() {
+    CorsConfiguration config = new CorsConfiguration();
+    // If Authorization/cookies are needed, keep true and keep explicit origins
+    config.setAllowCredentials(true);
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        List<String> paths = List.of(
-                "/auth/**",
-                "/md/selection",
-                "/md/candles",
-                "/md/stream",
-                "/md/last-ltp",
-                "/md/ltp",
-                "/md/sector-trades",
-                "/ops/live-status",
-                "/ops/influx-sanity",
-                "/ops/market-clock"
-        );
-        paths.forEach(p -> source.registerCorsConfiguration(p, config));
+    List<String> origins = Arrays.stream(allowedOrigins.split(","))
+        .map(String::trim)
+        .collect(Collectors.toList());
+    config.setAllowedOrigins(origins);
 
-        return new CorsFilter(source);
-    }
+    config.setAllowedHeaders(List.of(
+        "Authorization", "Content-Type", "Accept", "Origin", "Cache-Control", "X-Requested-With"
+    ));
+    config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
+    config.setExposedHeaders(List.of("Location"));
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+    return new CorsFilter(source);
+  }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -69,5 +69,5 @@ logging.level.root=INFO
 
 
 # --- UI CORS ---
-cors.allowedOrigins=https://frontendfortheautobot.vercel.app
+cors.allowedOrigins=https://frontendfortheautobot.vercel.app,http://localhost:4200
 


### PR DESCRIPTION
## Summary
- replace the servlet CORS filter to allow explicit Vercel/local origins with credentials, full headers, and preflight handling
- ensure the allowed origins property includes both the hosted frontend and localhost for development

## Testing
- ⚠️ `./mvnw -q -DskipTests package` *(fails: unable to reach https://repo.maven.apache.org/maven2)*

------
https://chatgpt.com/codex/tasks/task_e_68cac6be0e20832f86e15d6aebf55864