### PR TITLE
Align protobuf stack and enforce version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,24 +54,66 @@
                 </dependency>
 
 		<!-- Upstox SDK -->
-		<dependency>
-			<groupId>com.upstox.api</groupId>
-			<artifactId>upstox-java-sdk</artifactId>
-			<version>1.11.1</version>
-		</dependency>
+                <dependency>
+                        <groupId>com.upstox.api</groupId>
+                        <artifactId>upstox-java-sdk</artifactId>
+                        <version>1.11.1</version>
+                        <exclusions>
+                                <exclusion>
+                                        <groupId>com.google.protobuf</groupId>
+                                        <artifactId>protobuf-java</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                        <groupId>com.google.protobuf</groupId>
+                                        <artifactId>protobuf-java-util</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                        <groupId>ch.qos.logback</groupId>
+                                        <artifactId>logback-classic</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                        <groupId>ch.qos.logback</groupId>
+                                        <artifactId>logback-core</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                        <groupId>com.squareup.okhttp</groupId>
+                                        <artifactId>okhttp</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                        <groupId>com.squareup.okhttp</groupId>
+                                        <artifactId>logging-interceptor</artifactId>
+                                </exclusion>
+                                <exclusion>
+                                        <groupId>com.squareup.okio</groupId>
+                                        <artifactId>okio</artifactId>
+                                </exclusion>
+                        </exclusions>
+                </dependency>
 
 
-		<!-- Protobuf runtime -->
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
-			<version>${protoc.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java-util</artifactId>
-			<version>${protoc.version}</version>
-		</dependency>
+                <!-- Protobuf runtime -->
+                <dependency>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java</artifactId>
+                        <version>3.21.12</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.google.protobuf</groupId>
+                        <artifactId>protobuf-java-util</artifactId>
+                        <version>3.21.12</version>
+                </dependency>
+
+                <!-- Enforce okhttp3/okio line -->
+                <dependency>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>okhttp</artifactId>
+                        <version>4.12.0</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.squareup.okhttp3</groupId>
+                        <artifactId>logging-interceptor</artifactId>
+                        <version>4.12.0</version>
+                </dependency>
 
 		<!-- Lombok -->
 		<dependency>
@@ -104,11 +146,11 @@
 			<artifactId>influxdb-client-java</artifactId>
 			<version>6.9.0</version>
 		</dependency>
-		<dependency>
-			<groupId>com.squareup.okio</groupId>
-			<artifactId>okio</artifactId>
-			<version>3.4.0</version>
-		</dependency>
+                <dependency>
+                        <groupId>com.squareup.okio</groupId>
+                        <artifactId>okio</artifactId>
+                        <version>3.7.0</version>
+                </dependency>
                 <dependency>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-data-mongodb</artifactId>
@@ -127,6 +169,33 @@
 
         <build>
                 <plugins>
+                        <plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.4.1</version>
+                                <executions>
+                                        <execution>
+                                                <id>enforce-protobuf</id>
+                                                <goals>
+                                                        <goal>enforce</goal>
+                                                </goals>
+                                                <configuration>
+                                                        <rules>
+                                                                <bannedDependencies>
+                                                                        <excludes>
+                                                                                <exclude>com.google.protobuf:protobuf-java:(,3.21.12)</exclude>
+                                                                                <exclude>com.google.protobuf:protobuf-java:(3.21.12,)</exclude>
+                                                                                <exclude>com.google.protobuf:protobuf-java-util:(,3.21.12)</exclude>
+                                                                                <exclude>com.google.protobuf:protobuf-java-util:(3.21.12,)</exclude>
+                                                                        </excludes>
+                                                                        <searchTransitive>true</searchTransitive>
+                                                                </bannedDependencies>
+                                                        </rules>
+                                                        <fail>true</fail>
+                                                </configuration>
+                                        </execution>
+                                </executions>
+                        </plugin>
                         <!-- Java compiler & Lombok -->
                         <plugin>
                                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary
- exclude protobuf/logback/okhttp v2/okio transitive dependencies from the Upstox SDK
- add explicit protobuf-java/util 3.21.12 plus okhttp3/okio modern artifacts to the dependency list
- wire Maven Enforcer to fail the build if protobuf drift is introduced

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach Maven Central in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cad81a878c832f9ac6d3834a33a2e0