### PR TITLE
Align Upstox dependencies and CORS config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
                 <maven.failsafe.plugin.version>3.2.5</maven.failsafe.plugin.version>
 
                 <!-- align your Protobuf versions here -->
-                <protoc.version>3.25.3</protoc.version>
+                <protoc.version>3.25.4</protoc.version>
                 <!-- Skip frontend build by default to avoid requiring Node during CI -->
                 <skipFrontend>true</skipFrontend>
         </properties>
@@ -53,11 +53,11 @@
                         <artifactId>spring-boot-starter-actuator</artifactId>
                 </dependency>
 
-		<!-- Upstox SDK -->
+                <!-- Upstox SDK (uses OkHttp v2 packages) -->
                 <dependency>
                         <groupId>com.upstox.api</groupId>
                         <artifactId>upstox-java-sdk</artifactId>
-                        <version>1.11.1</version>
+                        <version>1.17</version>
                         <exclusions>
                                 <exclusion>
                                         <groupId>com.google.protobuf</groupId>
@@ -76,18 +76,26 @@
                                         <artifactId>logback-core</artifactId>
                                 </exclusion>
                                 <exclusion>
-                                        <groupId>com.squareup.okhttp</groupId>
+                                        <groupId>com.squareup.okhttp3</groupId>
                                         <artifactId>okhttp</artifactId>
                                 </exclusion>
                                 <exclusion>
-                                        <groupId>com.squareup.okhttp</groupId>
+                                        <groupId>com.squareup.okhttp3</groupId>
                                         <artifactId>logging-interceptor</artifactId>
                                 </exclusion>
-                                <exclusion>
-                                        <groupId>com.squareup.okio</groupId>
-                                        <artifactId>okio</artifactId>
-                                </exclusion>
                         </exclusions>
+                </dependency>
+
+                <!-- REQUIRED by Upstox SDK: OkHttp v2 API (com.squareup.okhttp.*) -->
+                <dependency>
+                        <groupId>com.squareup.okhttp</groupId>
+                        <artifactId>okhttp</artifactId>
+                        <version>2.7.5</version>
+                </dependency>
+                <dependency>
+                        <groupId>com.squareup.okhttp</groupId>
+                        <artifactId>logging-interceptor</artifactId>
+                        <version>2.7.5</version>
                 </dependency>
 
 
@@ -95,15 +103,15 @@
                 <dependency>
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protobuf-java</artifactId>
-                        <version>3.25.3</version>
+                        <version>3.25.4</version>
                 </dependency>
                 <dependency>
                         <groupId>com.google.protobuf</groupId>
                         <artifactId>protobuf-java-util</artifactId>
-                        <version>3.25.3</version>
+                        <version>3.25.4</version>
                 </dependency>
 
-                <!-- Enforce okhttp3/okio line -->
+                <!-- HTTP client for InfluxDB integration (okhttp3) -->
                 <dependency>
                         <groupId>com.squareup.okhttp3</groupId>
                         <artifactId>okhttp</artifactId>
@@ -147,11 +155,6 @@
 			<version>6.9.0</version>
 		</dependency>
                 <dependency>
-                        <groupId>com.squareup.okio</groupId>
-                        <artifactId>okio</artifactId>
-                        <version>3.7.0</version>
-                </dependency>
-                <dependency>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-starter-data-mongodb</artifactId>
                 </dependency>
@@ -183,10 +186,10 @@
                                                         <rules>
                                                                 <bannedDependencies>
                                                                         <excludes>
-                                                                                <exclude>com.google.protobuf:protobuf-java:(,3.25.3)</exclude>
-                                                                                <exclude>com.google.protobuf:protobuf-java:(3.25.3,)</exclude>
-                                                                                <exclude>com.google.protobuf:protobuf-java-util:(,3.25.3)</exclude>
-                                                                                <exclude>com.google.protobuf:protobuf-java-util:(3.25.3,)</exclude>
+                                                                                <exclude>com.google.protobuf:protobuf-java:(,3.25.4)</exclude>
+                                                                                <exclude>com.google.protobuf:protobuf-java:(3.25.4,)</exclude>
+                                                                                <exclude>com.google.protobuf:protobuf-java-util:(,3.25.4)</exclude>
+                                                                                <exclude>com.google.protobuf:protobuf-java-util:(3.25.4,)</exclude>
                                                                         </excludes>
                                                                         <searchTransitive>true</searchTransitive>
                                                                 </bannedDependencies>

--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -9,7 +9,6 @@ import org.springframework.web.filter.CorsFilter;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Configuration
 public class CorsConfig {
@@ -20,18 +19,10 @@ public class CorsConfig {
   @Bean
   public CorsFilter corsFilter() {
     CorsConfiguration config = new CorsConfiguration();
-    // If Authorization/cookies are needed, keep true and keep explicit origins
     config.setAllowCredentials(true);
-
-    List<String> origins = Arrays.stream(allowedOrigins.split(","))
-        .map(String::trim)
-        .collect(Collectors.toList());
-    config.setAllowedOrigins(origins);
-
-    config.setAllowedHeaders(List.of(
-        "Authorization", "Content-Type", "Accept", "Origin", "Cache-Control", "X-Requested-With"
-    ));
+    config.setAllowedOrigins(Arrays.stream(allowedOrigins.split(",")).map(String::trim).toList());
     config.setAllowedMethods(List.of("GET","POST","PUT","DELETE","OPTIONS"));
+    config.setAllowedHeaders(List.of("Authorization","Content-Type","Accept","Origin","Cache-Control","X-Requested-With"));
     config.setExposedHeaders(List.of("Location"));
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/trader/backend/config/UpstoxClientConfig.java
+++ b/src/main/java/com/trader/backend/config/UpstoxClientConfig.java
@@ -2,18 +2,21 @@ package com.trader.backend.config;
 
 import com.upstox.ApiClient;
 import com.upstox.Configuration;
-import com.upstox.auth.OAuth;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-
 
 @org.springframework.context.annotation.Configuration
 public class UpstoxClientConfig {
 
-    @Bean
-    public ApiClient upstoxApiClient() {
-        // Just create once; we’ll inject the token later
-        ApiClient client = Configuration.getDefaultApiClient();
-        client.setBasePath("https://api.upstox.com/v2");
-        return client;
-    }
+  @Value("${upstox.baseUrl:https://api.upstox.com/v3}")
+  private String baseUrl;
+
+  @Bean
+  public ApiClient upstoxApiClient() {
+    // This call touches com.squareup.okhttp.*; it will fail if OkHttp v2 is missing.
+    ApiClient client = Configuration.getDefaultApiClient();
+    client.setBasePath(baseUrl);
+    // Do not set token here; your UpstoxAuthService should do per-request auth header.
+    return client;
+  }
 }


### PR DESCRIPTION
## Summary
- bump the Upstox Java SDK to 1.17 and add the OkHttp v2/ protobuf 3.25.4 dependencies it expects
- expose a configurable Upstox ApiClient bean and refresh the CORS filter to allow FE origins with auth headers
- tighten the Maven enforcer rule so protobuf 3.25.4 remains pinned

## Testing
- `mvn -q -DskipTests package` *(fails: cannot reach repo.maven.apache.org to resolve spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8c2861c4832fada5689e87dbae13