### PR TITLE
Fix Influx OkHttp dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,14 +75,6 @@
                                         <groupId>ch.qos.logback</groupId>
                                         <artifactId>logback-core</artifactId>
                                 </exclusion>
-                                <exclusion>
-                                        <groupId>com.squareup.okhttp3</groupId>
-                                        <artifactId>okhttp</artifactId>
-                                </exclusion>
-                                <exclusion>
-                                        <groupId>com.squareup.okhttp3</groupId>
-                                        <artifactId>logging-interceptor</artifactId>
-                                </exclusion>
                         </exclusions>
                 </dependency>
 
@@ -117,6 +109,7 @@
                         <artifactId>okhttp</artifactId>
                         <version>4.12.0</version>
                 </dependency>
+                <!-- ✅ Okio 3.x is REQUIRED for OkHttp 4.x (InfluxDB) -->
                 <dependency>
                         <groupId>com.squareup.okio</groupId>
                         <artifactId>okio</artifactId>


### PR DESCRIPTION
## Summary
- allow the Upstox SDK to pull its okhttp3 artifacts instead of excluding them
- document that Okio 3.x is required for the okhttp4-based InfluxDB client

## Testing
- mvn -q clean package -DskipTests *(fails: Maven Central unreachable from container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc6bfff74832f8b13787be4fc7284