### PR TITLE
Automate NSE instrument refresh and search

### DIFF
--- a/src/main/java/com/trader/backend/market/InstrumentRefreshController.java
+++ b/src/main/java/com/trader/backend/market/InstrumentRefreshController.java
@@ -1,35 +1,14 @@
 package com.trader.backend.market;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.bulk.BulkWriteResult;
-import com.trader.backend.entity.NseInstrument;
+import com.trader.backend.market.MarketDtos;
+import com.trader.backend.service.NseInstrumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.bson.Document;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.core.BulkOperations;
-import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.index.Index;
-import org.springframework.data.mongodb.core.index.IndexOperations;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.http.HttpStatus;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
-
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Locale;
 
 @RestController
 @RequestMapping("/api/instruments")
@@ -37,112 +16,15 @@ import java.util.Locale;
 @Slf4j
 public class InstrumentRefreshController {
 
-    private static final TypeReference<List<NseInstrument>> LIST_TYPE = new TypeReference<>() {
-    };
-
-    private final MongoTemplate mongoTemplate;
-    private final ObjectMapper objectMapper;
-
-    @Value("${app.instruments.nse-json:}")
-    private String instrumentsPath;
+    private final NseInstrumentService nseInstrumentService;
 
     @PostMapping("/refresh")
     public MarketDtos.RefreshResult refresh() {
         try {
-            List<NseInstrument> all = loadInstruments();
-            int total = all.size();
-            List<NseInstrument> filtered = all.stream()
-                    .filter(this::isEligible)
-                    .toList();
-            ensureIndexes();
-            if (filtered.isEmpty()) {
-                log.info("event=INSTRUMENT_REFRESH_COMPLETED processed=0 upserted=0 skipped={}", total);
-                return new MarketDtos.RefreshResult(0, 0, total);
-            }
-
-            BulkOperations ops = mongoTemplate.bulkOps(BulkOperations.BulkMode.UNORDERED, NseInstrument.class);
-            int scheduled = 0;
-            for (NseInstrument instrument : filtered) {
-                if (!StringUtils.hasText(instrument.getInstrumentKey())) {
-                    continue;
-                }
-                Document document = new Document();
-                mongoTemplate.getConverter().write(instrument, document);
-                Object id = document.remove("_id");
-                if (id == null) {
-                    id = instrument.getInstrumentKey();
-                }
-                Query query = Query.query(Criteria.where("_id").is(id));
-                ops.upsert(query, Update.fromDocument(document));
-                scheduled++;
-            }
-
-            int upserted = 0;
-            if (scheduled > 0) {
-                BulkWriteResult result = ops.execute();
-                upserted = result.getUpserts().size() + result.getModifiedCount();
-            }
-            int processed = filtered.size();
-            int skipped = total - processed;
-            log.info("event=INSTRUMENT_REFRESH_COMPLETED processed={} upserted={} skipped={}", processed, upserted, skipped);
-            return new MarketDtos.RefreshResult(processed, upserted, skipped);
-        } catch (IOException e) {
+            return nseInstrumentService.refreshInstrumentSearchUniverse();
+        } catch (IllegalStateException e) {
             log.error("event=INSTRUMENT_REFRESH_FAILED reason={}", e.getMessage(), e);
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to refresh instruments");
         }
-    }
-
-    private List<NseInstrument> loadInstruments() throws IOException {
-        try (InputStream inputStream = resolveInputStream()) {
-            return objectMapper.readValue(inputStream, LIST_TYPE);
-        }
-    }
-
-    private InputStream resolveInputStream() throws IOException {
-        if (StringUtils.hasText(instrumentsPath)) {
-            Path path = Path.of(instrumentsPath);
-            if (Files.exists(path)) {
-                log.info("Loading instruments from configured path: {}", path);
-                return Files.newInputStream(path);
-            }
-            log.warn("Configured NSE.json path not found: {}", path);
-        }
-        InputStream resourceStream = InstrumentRefreshController.class.getClassLoader().getResourceAsStream("data/NSE.json");
-        if (resourceStream != null) {
-            return resourceStream;
-        }
-        throw new FileNotFoundException("Unable to locate NSE.json");
-    }
-
-    private boolean isEligible(NseInstrument instrument) {
-        if (instrument == null) {
-            return false;
-        }
-        String segment = instrument.getSegment();
-        if (!StringUtils.hasText(segment)) {
-            return false;
-        }
-        if ("NSE_EQ".equalsIgnoreCase(segment)) {
-            return true;
-        }
-        if ("NSE_FO".equalsIgnoreCase(segment)) {
-            String underlying = instrument.getUnderlyingSymbol();
-            String name = instrument.getName();
-            return (StringUtils.hasText(underlying) && underlying.equalsIgnoreCase("NIFTY"))
-                    || (StringUtils.hasText(name) && name.toUpperCase(Locale.ROOT).contains("NIFTY"));
-        }
-        if ("NSE_INDEX".equalsIgnoreCase(segment)) {
-            String name = instrument.getName();
-            return StringUtils.hasText(name) && name.toUpperCase(Locale.ROOT).contains("NIFTY");
-        }
-        return false;
-    }
-
-    private void ensureIndexes() {
-        IndexOperations indexOps = mongoTemplate.indexOps(NseInstrument.class);
-        indexOps.ensureIndex(new Index().on("expiry", Sort.Direction.ASC));
-        indexOps.ensureIndex(new Index().on("instrument_type", Sort.Direction.ASC));
-        indexOps.ensureIndex(new Index().on("underlying_key", Sort.Direction.ASC));
-        indexOps.ensureIndex(new Index().on("trading_symbol", Sort.Direction.ASC));
     }
 }

--- a/src/main/java/com/trader/backend/market/InstrumentSearchController.java
+++ b/src/main/java/com/trader/backend/market/InstrumentSearchController.java
@@ -1,6 +1,7 @@
 package com.trader.backend.market;
 
 import com.trader.backend.entity.NseInstrument;
+import com.trader.backend.service.NseInstrumentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
@@ -23,6 +24,7 @@ import java.util.regex.Pattern;
 public class InstrumentSearchController {
 
     private static final int MAX_LIMIT = 100;
+    private static final String COLLECTION = NseInstrumentService.INSTRUMENT_SEARCH_COLLECTION;
 
     private final MongoTemplate mongoTemplate;
 
@@ -42,7 +44,7 @@ public class InstrumentSearchController {
         Query mongoQuery = Query.query(criteria)
                 .limit(sanitizedLimit)
                 .with(Sort.by(Sort.Direction.ASC, "trading_symbol"));
-        List<NseInstrument> results = mongoTemplate.find(mongoQuery, NseInstrument.class, "nse_instruments");
+        List<NseInstrument> results = mongoTemplate.find(mongoQuery, NseInstrument.class, COLLECTION);
         return results.stream()
                 .map(this::toDto)
                 .toList();

--- a/src/main/java/com/trader/backend/service/NseInstrumentService.java
+++ b/src/main/java/com/trader/backend/service/NseInstrumentService.java
@@ -9,11 +9,15 @@ import java.time.Instant;
 import java.time.temporal.TemporalAdjusters;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.PostConstruct;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Service;
@@ -46,6 +50,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Service;
@@ -56,11 +62,14 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import org.springframework.context.annotation.Lazy;
 // imports to add at the top of NseInstrumentService
 import org.springframework.context.ApplicationEventPublisher;
 import com.trader.backend.events.FilteredPremiumsUpdatedEvent;
+import com.trader.backend.market.MarketDtos;
+import org.springframework.util.StringUtils;
 
 
 
@@ -79,6 +88,13 @@ public class NseInstrumentService {
     private final MongoTemplate mongoTemplate;
     private final NSEDownloaderService nseDownloaderService;
     private final ExpirySelectorService expirySelectorService;
+
+    @Value("${app.instruments.nse-json:}")
+    private String instrumentsPath;
+
+    public static final String INSTRUMENT_SEARCH_COLLECTION = "nse_instruments_search";
+    private static final TypeReference<List<NseInstrument>> NSE_LIST_TYPE = new TypeReference<>() {
+    };
 
     // Cache for NSE.json contents
     private List<NseInstrument> nseCache = Collections.emptyList();
@@ -127,6 +143,97 @@ public class NseInstrumentService {
     public List<NseInstrument> getCachedNse() {
         ensureNseJsonLoaded(false);
         return nseCache;
+    }
+
+    @PostConstruct
+    public void refreshInstrumentSearchOnStartup() {
+        try {
+            refreshInstrumentSearchUniverse();
+        } catch (Exception e) {
+            log.warn("Initial instrument search refresh failed", e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 8 * * MON-FRI", zone = "Asia/Kolkata")
+    public void refreshInstrumentSearchDaily() {
+        try {
+            refreshInstrumentSearchUniverse();
+        } catch (Exception e) {
+            log.error("Scheduled instrument search refresh failed", e);
+        }
+    }
+
+    public synchronized MarketDtos.RefreshResult refreshInstrumentSearchUniverse() {
+        try {
+            List<NseInstrument> all = loadInstrumentUniverse();
+            int total = all.size();
+            List<NseInstrument> eligible = all.stream()
+                    .filter(this::isEligibleForSearch)
+                    .peek(this::normalizeInstrument)
+                    .filter(i -> StringUtils.hasText(i.getInstrumentKey()))
+                    .toList();
+
+            mongoTemplate.dropCollection(INSTRUMENT_SEARCH_COLLECTION);
+            if (!eligible.isEmpty()) {
+                mongoTemplate.insert(eligible, INSTRUMENT_SEARCH_COLLECTION);
+            }
+            ensureSearchIndexes();
+
+            int processed = eligible.size();
+            int skipped = total - processed;
+            log.info("OPTIONS-REFRESH triggered collection={} processed={} saved={} skipped={}",
+                    INSTRUMENT_SEARCH_COLLECTION, processed, processed, skipped);
+            return new MarketDtos.RefreshResult(processed, processed, skipped);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to refresh instrument search universe", e);
+        }
+    }
+
+    private void ensureSearchIndexes() {
+        IndexOperations indexOps = mongoTemplate.indexOps(INSTRUMENT_SEARCH_COLLECTION);
+        indexOps.ensureIndex(new Index().on("trading_symbol", Sort.Direction.ASC));
+        indexOps.ensureIndex(new Index().on("name", Sort.Direction.ASC));
+        indexOps.ensureIndex(new Index().on("segment", Sort.Direction.ASC));
+        indexOps.ensureIndex(new Index().on("instrument_type", Sort.Direction.ASC));
+    }
+
+    private List<NseInstrument> loadInstrumentUniverse() throws IOException {
+        try (InputStream stream = resolveInstrumentStream()) {
+            return mapper.readValue(stream, NSE_LIST_TYPE);
+        }
+    }
+
+    private InputStream resolveInstrumentStream() throws IOException {
+        if (StringUtils.hasText(instrumentsPath)) {
+            Path path = Path.of(instrumentsPath);
+            if (Files.exists(path)) {
+                log.info("Loading instruments from configured path: {}", path);
+                return Files.newInputStream(path);
+            }
+            log.warn("Configured NSE.json path not found: {}", path);
+        }
+        InputStream resourceStream = getClass().getClassLoader().getResourceAsStream("data/NSE.json");
+        if (resourceStream != null) {
+            return resourceStream;
+        }
+        throw new FileNotFoundException("Unable to locate NSE.json");
+    }
+
+    private boolean isEligibleForSearch(NseInstrument instrument) {
+        if (instrument == null) {
+            return false;
+        }
+        String segment = instrument.getSegment();
+        if (!StringUtils.hasText(segment)) {
+            return false;
+        }
+        if (!segment.toUpperCase(Locale.ROOT).startsWith("NSE")) {
+            return false;
+        }
+        if (!StringUtils.hasText(instrument.getInstrumentKey())) {
+            return false;
+        }
+        return StringUtils.hasText(instrument.getTradingSymbol());
     }
 
     /** Stats returned by refreshFromNseJson. */


### PR DESCRIPTION
## Summary
- add startup and weekday scheduled refresh in `NseInstrumentService` to load a dedicated instrument-search collection from `NSE.json`
- expose refresh statistics through the existing controller and query the new collection in the search endpoint

## Testing
- `mvn -q -DskipTests package` *(fails: unable to reach Maven Central from the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc021ff334832f9bf9f38476d0412f