### PR TITLE
Add historical candle persistence and API

### DIFF
--- a/src/main/java/com/trader/backend/market/Candle.java
+++ b/src/main/java/com/trader/backend/market/Candle.java
@@ -1,0 +1,70 @@
+package com.trader.backend.market;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "candles")
+public class Candle {
+
+    @Id
+    private String id;
+
+    @Indexed
+    private String instrumentKey;
+
+    private String unit;
+
+    private int interval;
+
+    @Indexed
+    private Instant ts;
+
+    private double open;
+
+    private double high;
+
+    private double low;
+
+    private double close;
+
+    private long volume;
+
+    private long openInterest;
+
+    public static Candle create(String instrumentKey,
+                                String unit,
+                                int interval,
+                                Instant ts,
+                                double open,
+                                double high,
+                                double low,
+                                double close,
+                                long volume,
+                                long openInterest) {
+        String id = instrumentKey + "/" + ts.toEpochMilli();
+        return Candle.builder()
+                .id(id)
+                .instrumentKey(instrumentKey)
+                .unit(unit)
+                .interval(interval)
+                .ts(ts)
+                .open(open)
+                .high(high)
+                .low(low)
+                .close(close)
+                .volume(volume)
+                .openInterest(openInterest)
+                .build();
+    }
+}

--- a/src/main/java/com/trader/backend/market/CandleRepository.java
+++ b/src/main/java/com/trader/backend/market/CandleRepository.java
@@ -1,0 +1,15 @@
+package com.trader.backend.market;
+
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface CandleRepository extends MongoRepository<Candle, String> {
+
+    List<Candle> findByInstrumentKeyAndUnitAndIntervalAndTsBetween(String instrumentKey,
+                                                                   String unit,
+                                                                   int interval,
+                                                                   Instant from,
+                                                                   Instant to);
+}

--- a/src/main/java/com/trader/backend/market/HistoricalDataService.java
+++ b/src/main/java/com/trader/backend/market/HistoricalDataService.java
@@ -1,0 +1,223 @@
+package com.trader.backend.market;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.trader.backend.service.UpstoxAuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HistoricalDataService {
+
+    private static final ZoneId MARKET_ZONE = ZoneId.of("Asia/Kolkata");
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+    private static final DateTimeFormatter LEGACY_TS_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(MARKET_ZONE);
+    private static final Set<String> SUPPORTED_UNITS = Set.of("minutes", "hour", "day");
+    private static final Duration API_TIMEOUT = Duration.ofSeconds(15);
+
+    private final WebClient.Builder webClientBuilder;
+    private final UpstoxAuthService upstoxAuthService;
+    private final CandleRepository candleRepository;
+
+    public List<Candle> getOrFetchHistory(String instrumentKey,
+                                          String unit,
+                                          int interval,
+                                          LocalDate from,
+                                          LocalDate to) {
+        String normalizedUnit = normalizeUnit(unit);
+        LocalDate sanitizedFrom = Objects.requireNonNull(from, "from");
+        LocalDate sanitizedTo = Objects.requireNonNull(to, "to");
+
+        Instant fromInstant = sanitizedFrom.atStartOfDay(MARKET_ZONE).toInstant();
+        Instant toInstant = sanitizedTo.plusDays(1).atStartOfDay(MARKET_ZONE).minusNanos(1).toInstant();
+
+        List<Candle> existing = candleRepository
+                .findByInstrumentKeyAndUnitAndIntervalAndTsBetween(instrumentKey, normalizedUnit, interval, fromInstant, toInstant);
+
+        long expected = expectedCount(normalizedUnit, interval, sanitizedFrom, sanitizedTo);
+        if (expected <= 0) {
+            log.debug("Expected count for {} {} {} from {} to {} is <= 0; returning cached {} candles",
+                    instrumentKey, normalizedUnit, interval, sanitizedFrom, sanitizedTo, existing.size());
+            return sortByTimestamp(existing);
+        }
+
+        if (existing.size() >= expected) {
+            return sortByTimestamp(existing);
+        }
+
+        if (!ensureToken()) {
+            log.warn("Unable to validate Upstox token; returning cached candles ({} entries)", existing.size());
+            return sortByTimestamp(existing);
+        }
+
+        String accessToken = upstoxAuthService.getAccessToken();
+        if (accessToken == null || accessToken.isBlank()) {
+            log.warn("No Upstox access token available; returning cached candles ({} entries)", existing.size());
+            return sortByTimestamp(existing);
+        }
+
+        List<Candle> fetched = fetchFromUpstox(instrumentKey, normalizedUnit, interval, sanitizedFrom, sanitizedTo, accessToken);
+        if (CollectionUtils.isEmpty(fetched)) {
+            return sortByTimestamp(existing);
+        }
+
+        candleRepository.saveAll(fetched);
+
+        Map<String, Candle> combined = new HashMap<>();
+        for (Candle candle : existing) {
+            combined.put(candle.getId(), candle);
+        }
+        for (Candle candle : fetched) {
+            combined.put(candle.getId(), candle);
+        }
+        return sortByTimestamp(new ArrayList<>(combined.values()));
+    }
+
+    private String normalizeUnit(String unit) {
+        String normalized = unit == null ? "minutes" : unit.toLowerCase(Locale.ROOT);
+        if (!SUPPORTED_UNITS.contains(normalized)) {
+            throw new IllegalArgumentException("Unsupported unit: " + unit);
+        }
+        return normalized;
+    }
+
+    private boolean ensureToken() {
+        try {
+            Mono<Boolean> mono = upstoxAuthService.ensureValidToken();
+            Boolean ready = mono == null ? Boolean.FALSE : mono.block(API_TIMEOUT);
+            return Boolean.TRUE.equals(ready);
+        } catch (Exception e) {
+            log.warn("Failed to ensure Upstox token is valid", e);
+            return false;
+        }
+    }
+
+    private List<Candle> fetchFromUpstox(String instrumentKey,
+                                          String unit,
+                                          int interval,
+                                          LocalDate from,
+                                          LocalDate to,
+                                          String accessToken) {
+        try {
+            URI uri = UriComponentsBuilder
+                    .fromHttpUrl("https://api.upstox.com/v3/historical-candle")
+                    .pathSegment(instrumentKey)
+                    .pathSegment(unit)
+                    .pathSegment(String.valueOf(interval))
+                    .queryParam("from", DATE_FORMATTER.format(from))
+                    .queryParam("to", DATE_FORMATTER.format(to))
+                    .build()
+                    .encode()
+                    .toUri();
+
+            WebClient client = webClientBuilder.clone().build();
+            JsonNode response = client.get()
+                    .uri(uri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                    .retrieve()
+                    .bodyToMono(JsonNode.class)
+                    .block(API_TIMEOUT);
+
+            if (response == null) {
+                log.warn("No response received from Upstox historical candles API");
+                return List.of();
+            }
+
+            JsonNode candlesNode = response.path("data").path("candles");
+            if (!candlesNode.isArray()) {
+                log.warn("Unexpected historical candle payload: {}", response);
+                return List.of();
+            }
+
+            List<Candle> candles = new ArrayList<>();
+            for (JsonNode row : candlesNode) {
+                if (!row.isArray() || row.size() < 6) {
+                    continue;
+                }
+                Instant ts = parseTimestamp(row.get(0).asText(null));
+                if (ts == null) {
+                    continue;
+                }
+                double open = row.get(1).asDouble();
+                double high = row.get(2).asDouble();
+                double low = row.get(3).asDouble();
+                double close = row.get(4).asDouble();
+                long volume = row.get(5).isNumber() ? row.get(5).longValue() : 0L;
+                long openInterest = row.size() > 6 && row.get(6).isNumber() ? row.get(6).longValue() : 0L;
+                candles.add(Candle.create(instrumentKey, unit, interval, ts, open, high, low, close, volume, openInterest));
+            }
+            return candles;
+        } catch (Exception e) {
+            log.warn("Failed to fetch historical candles from Upstox", e);
+            return List.of();
+        }
+    }
+
+    private Instant parseTimestamp(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            return Instant.parse(value);
+        } catch (DateTimeParseException ignored) {
+            try {
+                LocalDateTime ldt = LocalDateTime.parse(value, LEGACY_TS_FORMATTER);
+                return ldt.atZone(MARKET_ZONE).toInstant();
+            } catch (DateTimeParseException dtpe) {
+                log.debug("Unable to parse candle timestamp: {}", value);
+                return null;
+            }
+        }
+    }
+
+    private List<Candle> sortByTimestamp(List<Candle> candles) {
+        candles.sort(Comparator.comparing(Candle::getTs));
+        return candles;
+    }
+
+    private long expectedCount(String unit, int interval, LocalDate from, LocalDate to) {
+        if (interval <= 0 || to.isBefore(from)) {
+            return 0;
+        }
+        ChronoUnit chronoUnit;
+        switch (unit) {
+            case "minutes" -> chronoUnit = ChronoUnit.MINUTES;
+            case "hour" -> chronoUnit = ChronoUnit.HOURS;
+            case "day" -> chronoUnit = ChronoUnit.DAYS;
+            default -> throw new IllegalArgumentException("Unsupported unit: " + unit);
+        }
+        long totalUnits = chronoUnit.between(from.atStartOfDay(MARKET_ZONE), to.plusDays(1).atStartOfDay(MARKET_ZONE));
+        if (totalUnits <= 0) {
+            return 0;
+        }
+        return (long) Math.ceil((double) totalUnits / interval);
+    }
+}

--- a/src/main/java/com/trader/backend/market/MarketHistoryController.java
+++ b/src/main/java/com/trader/backend/market/MarketHistoryController.java
@@ -1,118 +1,77 @@
 package com.trader.backend.market;
 
-import com.trader.backend.service.CandleService;
-import com.trader.backend.service.CandleService.Candle;
-import com.trader.backend.service.CandleService.CandleResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import reactor.core.publisher.Mono;
+import org.springframework.web.server.ResponseStatusException;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Set;
 
 @RestController
 @RequestMapping("/api/market")
+@RequiredArgsConstructor
 @Slf4j
 public class MarketHistoryController {
 
-    private final CandleService candleService;
+    private static final ZoneId MARKET_ZONE = ZoneId.of("Asia/Kolkata");
+    private static final Set<String> SUPPORTED_UNITS = Set.of("minutes", "hour", "day");
 
-    public MarketHistoryController(ObjectProvider<CandleService> candleServiceProvider) {
-        this.candleService = candleServiceProvider.getIfAvailable();
-    }
+    private final HistoricalDataService historicalDataService;
 
     @GetMapping("/history")
-    public Mono<MarketDtos.MarketHistoryResponse> history(@RequestParam("instrumentKey") String instrumentKey,
-                                                          @RequestParam(value = "tf", defaultValue = "1m") String timeframe,
-                                                          @RequestParam(value = "limit", defaultValue = "300") int limit) {
+    public List<CandleDto> history(@RequestParam("instrumentKey") String instrumentKey,
+                                   @RequestParam(value = "unit", defaultValue = "minutes") String unit,
+                                   @RequestParam(value = "interval", defaultValue = "1") int interval,
+                                   @RequestParam(value = "from", required = false)
+                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+                                   @RequestParam(value = "to", required = false)
+                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
         if (!StringUtils.hasText(instrumentKey)) {
-            return Mono.error(new IllegalArgumentException("instrumentKey is required"));
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "instrumentKey is required");
         }
 
-        int sanitizedLimit = Math.min(Math.max(limit, 1), 1000);
-        String normalizedTf = normalizeTf(timeframe);
-        boolean influxSupported = !"1s".equalsIgnoreCase(timeframe);
-
-        if (candleService == null || !influxSupported) {
-            log.debug("Returning dummy history for instrumentKey={} tf={}", instrumentKey, timeframe);
-            return Mono.just(dummyHistory(instrumentKey, timeframe, sanitizedLimit));
+        String normalizedUnit = normalizeUnit(unit);
+        if (interval <= 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "interval must be positive");
         }
 
-        return candleService.fetchCandles(List.of(instrumentKey), normalizedTf, sanitizedLimit)
-                .map(responses -> responses.isEmpty() ? null : responses.get(0))
-                .flatMap(response -> {
-                    if (response == null || response.candles().isEmpty()) {
-                        log.debug("No historical candles available from Influx for instrumentKey={} tf={}", instrumentKey, normalizedTf);
-                        return Mono.just(dummyHistory(instrumentKey, timeframe, sanitizedLimit));
-                    }
-                    return Mono.just(fromResponse(instrumentKey, timeframe, response));
-                })
-                .onErrorResume(ex -> {
-                    log.warn("Falling back to dummy history for instrumentKey={} tf={} reason={}", instrumentKey, timeframe, ex.getMessage());
-                    return Mono.just(dummyHistory(instrumentKey, timeframe, sanitizedLimit));
-                });
+        LocalDate today = LocalDate.now(MARKET_ZONE);
+        LocalDate startDate = from != null ? from : today;
+        LocalDate endDate = to != null ? to : startDate;
+        if (endDate.isBefore(startDate)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "to must be on or after from");
+        }
+
+        List<Candle> candles = historicalDataService.getOrFetchHistory(instrumentKey, normalizedUnit, interval, startDate, endDate);
+        return candles.stream()
+                .map(candle -> new CandleDto(
+                        candle.getTs() != null ? candle.getTs().toEpochMilli() : 0L,
+                        candle.getOpen(),
+                        candle.getHigh(),
+                        candle.getLow(),
+                        candle.getClose(),
+                        candle.getVolume()))
+                .toList();
     }
 
-    private String normalizeTf(String tf) {
-        String normalized = tf == null ? "1m" : tf.toLowerCase(Locale.ROOT);
-        return switch (normalized) {
-            case "5m" -> "5m";
-            case "15m" -> "15m";
-            case "3m" -> "3m";
-            default -> "1m";
-        };
+    private String normalizeUnit(String unit) {
+        String normalized = unit == null ? "minutes" : unit.toLowerCase(Locale.ROOT);
+        if (!SUPPORTED_UNITS.contains(normalized)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unsupported unit");
+        }
+        return normalized;
     }
 
-    private MarketDtos.MarketHistoryResponse fromResponse(String instrumentKey, String requestedTf, CandleResponse response) {
-        List<MarketDtos.Candle> candles = new ArrayList<>(response.candles().size());
-        for (Candle candle : response.candles()) {
-            try {
-                Instant ts = Instant.parse(candle.t());
-                candles.add(new MarketDtos.Candle(
-                        ts.toEpochMilli(),
-                        candle.o(),
-                        candle.h(),
-                        candle.l(),
-                        candle.c(),
-                        candle.v()
-                ));
-            } catch (DateTimeParseException e) {
-                log.debug("Skipping candle with unparsable timestamp: {}", candle.t());
-            }
-        }
-        return new MarketDtos.MarketHistoryResponse(instrumentKey, requestedTf, candles);
-    }
-
-    private MarketDtos.MarketHistoryResponse dummyHistory(String instrumentKey, String timeframe, int limit) {
-        Duration step = switch (timeframe.toLowerCase(Locale.ROOT)) {
-            case "1s" -> Duration.ofSeconds(1);
-            case "5m" -> Duration.ofMinutes(5);
-            default -> Duration.ofMinutes(1);
-        };
-        List<MarketDtos.Candle> candles = new ArrayList<>(limit);
-        Instant now = Instant.now();
-        double price = 100.0 + ThreadLocalRandom.current().nextDouble(10.0);
-        for (int i = limit; i >= 1; i--) {
-            Instant ts = now.minus(step.multipliedBy(i));
-            double drift = ThreadLocalRandom.current().nextDouble(-1.5, 1.5);
-            double open = price;
-            double close = Math.max(1.0, open + drift);
-            double high = Math.max(open, close) + ThreadLocalRandom.current().nextDouble(0.5);
-            double low = Math.min(open, close) - ThreadLocalRandom.current().nextDouble(0.5);
-            double volume = 50 + ThreadLocalRandom.current().nextDouble(250.0);
-            candles.add(new MarketDtos.Candle(ts.toEpochMilli(), open, high, low, close, volume));
-            price = close;
-        }
-        return new MarketDtos.MarketHistoryResponse(instrumentKey, timeframe, candles);
+    public record CandleDto(long ts, double o, double h, double l, double c, long v) {
     }
 }

--- a/src/main/java/com/trader/backend/service/UpstoxAuthService.java
+++ b/src/main/java/com/trader/backend/service/UpstoxAuthService.java
@@ -230,6 +230,13 @@ public class UpstoxAuthService {
         return accessToken.get();
     }
 
+    /**
+     * Convenience accessor used by services that need the raw bearer token.
+     */
+    public String getAccessToken() {
+        return currentToken();
+    }
+
     public void setCurrentToken(String token) {
         accessToken.set(token);
         apiClient.addDefaultHeader("Authorization", "Bearer " + token);


### PR DESCRIPTION
## Summary
- add a Mongo candle document and repository to persist historical OHLC data
- implement a historical data service that reuses cached candles or fetches from the Upstox V3 API when needed
- replace the market history endpoint to serve cached candles and expose a token accessor for reuse in API clients

## Testing
- `./mvnw -q -DskipTests package` *(fails: unable to download parent POM because Maven Central is unreachable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc09399bcc832fa21ff0e16f689d02