### PR TITLE
Fix CORS and Upstox history fetching

### DIFF
--- a/src/main/java/com/trader/backend/config/CorsConfig.java
+++ b/src/main/java/com/trader/backend/config/CorsConfig.java
@@ -26,7 +26,7 @@ public class CorsConfig {
     config.setExposedHeaders(List.of("Location"));
 
     UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    List.of("/auth/**", "/md/**", "/ops/**", "/ws/**")
+    List.of("/auth/**", "/md/**", "/ops/**", "/api/**", "/ws/**")
         .forEach(path -> source.registerCorsConfiguration(path, config));
     return new CorsFilter(source);
   }

--- a/src/main/java/com/trader/backend/market/HistoricalDataService.java
+++ b/src/main/java/com/trader/backend/market/HistoricalDataService.java
@@ -12,7 +12,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.util.UriComponentsBuilder;
 import reactor.core.publisher.Mono;
 
-import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -24,11 +23,11 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -39,7 +38,6 @@ public class HistoricalDataService {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
     private static final DateTimeFormatter LEGACY_TS_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(MARKET_ZONE);
-    private static final Set<String> SUPPORTED_UNITS = Set.of("minutes", "hour", "day");
     private static final Duration API_TIMEOUT = Duration.ofSeconds(15);
 
     private final WebClient.Builder webClientBuilder;
@@ -58,8 +56,13 @@ public class HistoricalDataService {
         Instant fromInstant = sanitizedFrom.atStartOfDay(MARKET_ZONE).toInstant();
         Instant toInstant = sanitizedTo.plusDays(1).atStartOfDay(MARKET_ZONE).minusNanos(1).toInstant();
 
-        List<Candle> existing = candleRepository
-                .findByInstrumentKeyAndUnitAndIntervalAndTsBetween(instrumentKey, normalizedUnit, interval, fromInstant, toInstant);
+        List<Candle> cached = new ArrayList<>(candleRepository
+                .findByInstrumentKeyAndUnitAndIntervalAndTsBetween(instrumentKey, normalizedUnit, interval, fromInstant, toInstant));
+        for (String alias : legacyAliases(normalizedUnit)) {
+            cached.addAll(candleRepository
+                    .findByInstrumentKeyAndUnitAndIntervalAndTsBetween(instrumentKey, alias, interval, fromInstant, toInstant));
+        }
+        List<Candle> existing = dedupe(cached);
 
         long expected = expectedCount(normalizedUnit, interval, sanitizedFrom, sanitizedTo);
         if (expected <= 0) {
@@ -101,11 +104,48 @@ public class HistoricalDataService {
     }
 
     private String normalizeUnit(String unit) {
-        String normalized = unit == null ? "minutes" : unit.toLowerCase(Locale.ROOT);
-        if (!SUPPORTED_UNITS.contains(normalized)) {
-            throw new IllegalArgumentException("Unsupported unit: " + unit);
+        String normalized = unit == null ? "minute" : unit.toLowerCase(Locale.ROOT);
+        return switch (normalized) {
+            case "minute", "minutes" -> "minute";
+            case "hour", "hours" -> "hour";
+            case "day", "days" -> "day";
+            case "week", "weeks" -> "week";
+            case "month", "months" -> "month";
+            default -> throw new IllegalArgumentException("Unsupported unit: " + unit);
+        };
+    }
+
+    private List<String> legacyAliases(String unit) {
+        return switch (unit) {
+            case "minute" -> List.of("minutes");
+            case "hour" -> List.of("hours");
+            case "day" -> List.of("days");
+            case "week" -> List.of("weeks");
+            case "month" -> List.of("months");
+            default -> List.of();
+        };
+    }
+
+    private List<Candle> dedupe(List<Candle> candles) {
+        Map<String, Candle> unique = new LinkedHashMap<>();
+        List<Candle> withoutId = new ArrayList<>();
+        for (Candle candle : candles) {
+            if (candle == null) {
+                continue;
+            }
+            String id = candle.getId();
+            if ((id == null || id.isBlank()) && candle.getTs() != null) {
+                id = candle.getInstrumentKey() + "/" + candle.getTs().toEpochMilli();
+            }
+            if (id == null || id.isBlank()) {
+                withoutId.add(candle);
+                continue;
+            }
+            unique.put(id, candle);
         }
-        return normalized;
+        List<Candle> result = new ArrayList<>(unique.values());
+        result.addAll(withoutId);
+        return result;
     }
 
     private boolean ensureToken() {
@@ -126,20 +166,19 @@ public class HistoricalDataService {
                                           LocalDate to,
                                           String accessToken) {
         try {
-            URI uri = UriComponentsBuilder
-                    .fromHttpUrl("https://api.upstox.com/v3/historical-candle")
-                    .pathSegment(instrumentKey)
-                    .pathSegment(unit)
-                    .pathSegment(String.valueOf(interval))
-                    .queryParam("from", DATE_FORMATTER.format(from))
-                    .queryParam("to", DATE_FORMATTER.format(to))
-                    .build()
+            String path = UriComponentsBuilder
+                    .fromPath("/historical-candle/{instrumentKey}/{unit}/{interval}")
+                    .queryParam("to_date", DATE_FORMATTER.format(to))
+                    .queryParam("from_date", DATE_FORMATTER.format(from))
+                    .buildAndExpand(instrumentKey, unit, interval)
                     .encode()
-                    .toUri();
+                    .toUriString();
 
-            WebClient client = webClientBuilder.clone().build();
+            WebClient client = webClientBuilder.clone()
+                    .baseUrl("https://api.upstox.com/v3")
+                    .build();
             JsonNode response = client.get()
-                    .uri(uri)
+                    .uri(path)
                     .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                     .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
                     .retrieve()
@@ -209,9 +248,11 @@ public class HistoricalDataService {
         }
         ChronoUnit chronoUnit;
         switch (unit) {
-            case "minutes" -> chronoUnit = ChronoUnit.MINUTES;
+            case "minute" -> chronoUnit = ChronoUnit.MINUTES;
             case "hour" -> chronoUnit = ChronoUnit.HOURS;
             case "day" -> chronoUnit = ChronoUnit.DAYS;
+            case "week" -> chronoUnit = ChronoUnit.WEEKS;
+            case "month" -> chronoUnit = ChronoUnit.MONTHS;
             default -> throw new IllegalArgumentException("Unsupported unit: " + unit);
         }
         long totalUnits = chronoUnit.between(from.atStartOfDay(MARKET_ZONE), to.plusDays(1).atStartOfDay(MARKET_ZONE));

--- a/src/main/java/com/trader/backend/market/MarketHistoryController.java
+++ b/src/main/java/com/trader/backend/market/MarketHistoryController.java
@@ -35,8 +35,12 @@ public class MarketHistoryController {
                                    @RequestParam(value = "interval", defaultValue = "1minute") String interval,
                                    @RequestParam(value = "from", required = false)
                                    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+                                   @RequestParam(value = "from_date", required = false)
+                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
                                    @RequestParam(value = "to", required = false)
-                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+                                   @RequestParam(value = "to_date", required = false)
+                                   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
         if (!StringUtils.hasText(instrumentKey)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "instrumentKey is required");
         }
@@ -51,26 +55,27 @@ public class MarketHistoryController {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid interval: " + interval);
         }
 
-        int units = matcher.group(1) != null ? Integer.parseInt(matcher.group(1)) : 1;
-        if (units <= 0) {
+        int parsedInterval = matcher.group(1) != null ? Integer.parseInt(matcher.group(1)) : 1;
+        if (parsedInterval <= 0) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "interval must be positive");
         }
 
-        String unit = matcher.group(2).toLowerCase(Locale.ROOT);
-        String normalizedUnit = unit.equals("day") ? "day" : "minutes";
-        int normalizedInterval = unit.equals("day") ? units : units;
+        String parsedUnit = matcher.group(2).toLowerCase(Locale.ROOT);
+        if ("day".equals(parsedUnit) && parsedInterval != 1) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Daily interval must be 1day");
+        }
 
         LocalDate today = LocalDate.now(MARKET_ZONE);
-        LocalDate startDate = from != null ? from : today;
-        LocalDate endDate = to != null ? to : startDate;
+        LocalDate startDate = coalesceDate(from, fromDate, today);
+        LocalDate endDate = coalesceDate(to, toDate, startDate);
         if (endDate.isBefore(startDate)) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "to must be on or after from");
         }
 
         List<Candle> candles = historicalDataService.getOrFetchHistory(
                 instrumentKey,
-                normalizedUnit,
-                normalizedInterval,
+                parsedUnit,
+                parsedInterval,
                 startDate,
                 endDate);
         return candles.stream()
@@ -85,5 +90,15 @@ public class MarketHistoryController {
     }
 
     public record CandleDto(long ts, double o, double h, double l, double c, long v) {
+    }
+
+    private LocalDate coalesceDate(LocalDate primary, LocalDate secondary, LocalDate fallback) {
+        if (primary != null) {
+            return primary;
+        }
+        if (secondary != null) {
+            return secondary;
+        }
+        return fallback;
     }
 }


### PR DESCRIPTION
## Summary
- widen backend CORS coverage so API and WebSocket routes are accessible to the frontend
- allow history endpoint to accept flexible interval strings and alternate date parameters
- normalize cached candle lookups and fetch data from the Upstox historical-candle v3 endpoint before upserting into MongoDB

## Testing
- mvn -q clean package -DskipTests *(fails: dependency download blocked by missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68cc35108910832f915b4ebb24616968